### PR TITLE
chore: Add self-hosted runners.

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -16,11 +16,28 @@ jobs:
           cd shaders && cargo run --release && cd ..
           git diff --exit-code --no-ext-diff crates/renderling/src/linkage
 
-  #renderling-test:
-  #  runs-on: [ubuntu-latest, gpu]
-  #  steps:
-  #    - uses: actions/checkout@v2
-  #    - uses: actions-rs/toolchain@v1
-  #      with:
-  #        toolchain: stable
-  #    - run: cargo test
+  renderling-test:
+    strategy:
+      matrix:
+        label: [pi4, intel, amd]
+    runs-on: ${{ matrix.label }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+      - run: cargo test
+        env:
+          RUST_BACKTRACE: 1
+
+  renderling-clippy:
+    strategy:
+      matrix:
+        label: [pi4, intel, amd]
+    runs-on: ${{ matrix.label }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+      - run: cargo clippy


### PR DESCRIPTION
Uses the matrix strategy to run tests and clippy against your fancy new self-hosted runners.  It fails, but I'm pretty sure that the failures are legit.