### PR TITLE
chore: Don't fail-fast matrix builds.

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -18,13 +18,15 @@ jobs:
 
   renderling-test:
     strategy:
+      fail-fast: false
       matrix:
         label: [pi4, intel, amd]
+    continue-on-error: true
     runs-on: ${{ matrix.label }}
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
-        with:    
+        with:
           toolchain: stable
       - run: cargo test
         env:
@@ -32,8 +34,10 @@ jobs:
 
   renderling-clippy:
     strategy:
+      fail-fast: false
       matrix:
         label: [pi4, intel, amd]
+    continue-on-error: true
     runs-on: ${{ matrix.label }}
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Disables fail-fast on the CI matrix, so that it won't cancel all the jobs as soon as one fails.