### PR TITLE
chore: Fix CI (some more)

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -28,9 +28,15 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
+      - run: apt-get -q -y update && apt-get -q -y install libvulkan1
       - run: RUST_LOG=trace cargo test
         env:
           RUST_BACKTRACE: 1
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: test-output-${{ matrix.label }}
+          path: test_output/**/*.png
 
   renderling-clippy:
     strategy:


### PR DESCRIPTION
1. Install `libvulkan1` in runners.
2. Store `test_output` images as build artifacts for debugging.

On my fork you can see that the `amd` build passes, but the intel and pi4 ones do not.
https://github.com/jimsynz/renderling/actions/runs/9145379615/job/25144253991