### PR TITLE
fix: renderling crate doesn't need to by dylib

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -15,11 +15,10 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: shaders
-      - run: |
-          # ensure the shader binaries were properly checked in
-          rm -rf crates/renderling/src/linkage/*.spv
-          cd shaders && cargo run --release && cd ..
-          git diff --exit-code --no-ext-diff crates/renderling/src/linkage
+      # ensure the shader binaries were properly checked in
+      - run: rm -rf crates/renderling/src/linkage/*.spv
+      - run: cd shaders && cargo run --release && cd ..
+      - run: git diff --exit-code --no-ext-diff crates/renderling/src/linkage
 
   renderling-clippy:
     runs-on: ubuntu-latest

--- a/crates/renderling/Cargo.toml
+++ b/crates/renderling/Cargo.toml
@@ -11,9 +11,6 @@ readme = "../../README.md"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
-[lib]
-crate-type = ["lib", "dylib"]
-
 [features]
 default = ["gltf", "sdf", "shaders", "tutorial", "winit"]
 shaders = [

--- a/crates/renderling/Cargo.toml
+++ b/crates/renderling/Cargo.toml
@@ -11,6 +11,9 @@ readme = "../../README.md"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[lib]
+crate-type = ["rlib", "cdylib"]
+
 [features]
 default = ["gltf", "sdf", "shaders", "tutorial", "winit"]
 shaders = [


### PR DESCRIPTION
This removes the `dylib` crate type from renderling, which doesn't need to be dynamically loaded.

It's surprising to me that I haven't built the `example` GLTF viewer on Linux since adding support for WASM!

Thanks for the report @wusticality.