### PR TITLE
fix: don't auto convert LF to CRLF on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,3 +4,4 @@
 *.yaml text
 *.spv binary
 *.wgsl linguist-generated=true binary
+* text=auto eol=lf


### PR DESCRIPTION
use LF in gitattributes, fixes #190