### PR TITLE
fix: WIP test infra for WASM

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -2,6 +2,7 @@
 xtask = "run --package xtask --"
 shaders = "xtask compile-shaders"
 linkage = "xtask generate-linkage"
+test-wasm = "xtask test-wasm"
 
 [build]
 rustflags = ["--cfg=web_sys_unstable_apis"]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,6 +19,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2187590a23ab1e3df8681afdf0987c48504d80291f002fcdb651f0ef5e25169"
 
 [[package]]
+name = "addr2line"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
 name = "adler2"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -342,10 +351,85 @@ dependencies = [
 ]
 
 [[package]]
+name = "axum"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "021e862c184ae977658b36c4500f7feac3221ca5da43e3f25bd04ab6c79a29b5"
+dependencies = [
+ "axum-core",
+ "bytes",
+ "form_urlencoded",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68464cd0412f486726fb3373129ef5d2993f90c34bc2bc1c1e9943b2f4fc7ca6"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "rustversion",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "backtrace"
+version = "0.3.75"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6806a6321ec58106fea15becdad98371e28d92ccbc7c8f1b3b6dd724fe8f1002"
+dependencies = [
+ "addr2line",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
 name = "base64"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bit-set"
@@ -719,7 +803,7 @@ dependencies = [
  "bitflags 1.3.2",
  "core-foundation 0.9.4",
  "core-graphics-types 0.1.3",
- "foreign-types",
+ "foreign-types 0.5.0",
  "libc",
 ]
 
@@ -753,7 +837,7 @@ checksum = "c9d2790b5c08465d49f8dc05c8bcae9fea467855947db39b0f8145c091aaced5"
 dependencies = [
  "core-foundation 0.9.4",
  "core-graphics",
- "foreign-types",
+ "foreign-types 0.5.0",
  "libc",
 ]
 
@@ -913,6 +997,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd0c93bb4b0c6d9b77f4435b0ae98c24d17f1c45b2ff844c6151a07256ca923b"
 
 [[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+]
+
+[[package]]
 name = "dlib"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -971,6 +1066,15 @@ name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "env_logger"
@@ -1109,6 +1213,7 @@ dependencies = [
  "wasm-bindgen-test",
  "web-sys",
  "wgpu",
+ "winit",
 ]
 
 [[package]]
@@ -1188,6 +1293,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8bf7cc16383c4b8d58b9905a8509f02926ce3058053c056376248d958c9df1e8"
 
 [[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
 name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1220,12 +1331,21 @@ dependencies = [
 
 [[package]]
 name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared 0.1.1",
+]
+
+[[package]]
+name = "foreign-types"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
 dependencies = [
  "foreign-types-macros",
- "foreign-types-shared",
+ "foreign-types-shared 0.3.1",
 ]
 
 [[package]]
@@ -1241,9 +1361,24 @@ dependencies = [
 
 [[package]]
 name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
+name = "foreign-types-shared"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
 
 [[package]]
 name = "freetype-sys"
@@ -1261,6 +1396,15 @@ name = "fuchsia-cprng"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
+
+[[package]]
+name = "futures-channel"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+dependencies = [
+ "futures-core",
+]
 
 [[package]]
 name = "futures-core"
@@ -1297,6 +1441,46 @@ checksum = "f5edaec856126859abb19ed65f39e90fea3a9574b9707f13539acf4abf7eb532"
 dependencies = [
  "futures-core",
  "pin-project-lite",
+]
+
+[[package]]
+name = "futures-macro"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
+
+[[package]]
+name = "futures-task"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+
+[[package]]
+name = "futures-util"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+dependencies = [
+ "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
+ "futures-task",
+ "memchr",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
 ]
 
 [[package]]
@@ -1353,6 +1537,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "gimli"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
+
+[[package]]
 name = "gl_generator"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1390,7 +1580,7 @@ version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3ce1918195723ce6ac74e80542c5a96a40c2b26162c1957a5cd70799b8cacf7"
 dependencies = [
- "base64",
+ "base64 0.13.1",
  "byteorder",
  "gltf-json",
  "image 0.25.6",
@@ -1522,6 +1712,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "h2"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3c0b69cfcb4e1b9f1bf2f53f95f766e4661169728ec61cd3fe5a0166f2d1386"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "half"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1577,6 +1786,52 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfa686283ad6dd069f105e5ab091b04c62850d3e4cf5d67debad1933f55023df"
 
 [[package]]
+name = "http"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4a85d31aea989eead29a3aaf9e1115a180df8282431156e533de47660892565"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
 name = "human-repr"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1587,6 +1842,87 @@ name = "humantime"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b112acc8b3adf4b107a8ec20977da0273a8c386765a3ec0229bd500a1443f9f"
+
+[[package]]
+name = "hyper"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb3aa54a13a0dfe7fbe3a59e0c76093041720fdc77b110cc0fc260fafb4dc51e"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "h2",
+ "http",
+ "http-body",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "pin-utils",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+dependencies = [
+ "bytes",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d9b05277c7e8da2c93a568989bb6207bef0112e8d17df7a6eda4a3cf143bc5e"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "ipnet",
+ "libc",
+ "percent-encoding",
+ "pin-project-lite",
+ "socket2",
+ "system-configuration",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "windows-registry",
+]
 
 [[package]]
 name = "iana-time-zone"
@@ -1624,6 +1960,113 @@ dependencies = [
  "rand 0.6.5",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "icu_collections"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "200072f5d0e3614556f94a9930d5dc3e0662a652823904c3a75dc3b0af7fee47"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cde2700ccaed3872079a65fb1a78f6c0a36c91570f28755dda67bc8f7d9f00a"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "436880e8e18df4d7bbc06d58432329d6458cc84531f7ac5f024e93deadb37979"
+dependencies = [
+ "displaydoc",
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00210d6893afc98edb752b664b8890f0ef174c8adbb8d0be9710fa66fbbf72d3"
+
+[[package]]
+name = "icu_properties"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "016c619c1eeb94efb86809b015c58f479963de65bdb6253345c1a1276f22e32b"
+dependencies = [
+ "displaydoc",
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "potential_utf",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "298459143998310acd25ffe6810ed544932242d3f07083eee1084d83a71bd632"
+
+[[package]]
+name = "icu_provider"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03c80da27b5f4187909049ee2d72f276f0d9f99a42c306bd0131ecfe04d8e5af"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "stable_deref_trait",
+ "tinystr",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
 ]
 
 [[package]]
@@ -1723,6 +2166,33 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.104",
+]
+
+[[package]]
+name = "io-uring"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "046fa2d4d00aea763528b4950358d0ead425372445dc8ff86312b3c69ff7727b"
+dependencies = [
+ "bitflags 2.9.1",
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
+name = "ipnet"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
+
+[[package]]
+name = "iri-string"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc5ebe9c3a1a7a5127f920a418f7585e9e758e911d0466ed004f393b0e380b2"
+dependencies = [
+ "memchr",
+ "serde",
 ]
 
 [[package]]
@@ -1896,6 +2366,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
 
 [[package]]
+name = "litemap"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
+
+[[package]]
 name = "litrs"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1908,6 +2384,8 @@ dependencies = [
  "async-fs",
  "js-sys",
  "send_wrapper",
+ "serde",
+ "serde_json",
  "snafu 0.8.6",
  "wasm-bindgen",
  "wasm-bindgen-futures",
@@ -2001,6 +2479,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
 name = "maybe-rayon"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2034,11 +2518,17 @@ dependencies = [
  "bitflags 2.9.1",
  "block",
  "core-graphics-types 0.2.0",
- "foreign-types",
+ "foreign-types 0.5.0",
  "log",
  "objc",
  "paste",
 ]
+
+[[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "minicov"
@@ -2067,6 +2557,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "mio"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
+dependencies = [
+ "libc",
+ "wasi 0.11.1+wasi-snapshot-preview1",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "naga"
 version = "26.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2091,6 +2592,23 @@ dependencies = [
  "spirv",
  "thiserror 2.0.12",
  "unicode-ident",
+]
+
+[[package]]
+name = "native-tls"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87de3442987e9dbec73158d5c715e7ad9072fda936bb03d19d7fa10e00520f0e"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
 ]
 
 [[package]]
@@ -2128,6 +2646,16 @@ name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
+
+[[package]]
+name = "new_mime_guess"
+version = "4.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02a2dfb3559d53e90b709376af1c379462f7fb3085a0177deb73e6ea0d99eff4"
+dependencies = [
+ "mime",
+ "unicase",
+]
 
 [[package]]
 name = "nom"
@@ -2440,6 +2968,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "object"
+version = "0.36.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2450,6 +2987,50 @@ name = "once_cell_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
+
+[[package]]
+name = "openssl"
+version = "0.10.73"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8505734d46c8ab1e19a1dce3aef597ad87dcb4c37e7188231769bd6bd51cebf8"
+dependencies = [
+ "bitflags 2.9.1",
+ "cfg-if",
+ "foreign-types 0.3.2",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+]
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90096e2e47630d78b7d1c20952dc621f957103f8bc2c8359ec81290d75238571"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "option-ext"
@@ -2588,6 +3169,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
 
 [[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
 name = "piper"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2691,6 +3278,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
 dependencies = [
  "portable-atomic",
+]
+
+[[package]]
+name = "potential_utf"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5a7c30837279ca13e7c867e9e40053bc68740f988cb07f7ca6df43cc734b585"
+dependencies = [
+ "zerovec",
 ]
 
 [[package]]
@@ -3165,9 +3761,13 @@ dependencies = [
  "snafu 0.8.6",
  "spirv-std",
  "ttf-parser 0.20.0",
+ "wasm-bindgen",
+ "wasm-bindgen-test",
+ "web-sys",
  "wgpu",
  "wgpu-core",
  "winit",
+ "wire-types",
 ]
 
 [[package]]
@@ -3182,10 +3782,73 @@ dependencies = [
 ]
 
 [[package]]
+name = "reqwest"
+version = "0.12.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d429f34c8092b2d42c7c93cec323bb4adeb7c67698f70839adec842ec10c7ceb"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-tls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "mime",
+ "native-tls",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-native-tls",
+ "tokio-util",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-streams",
+ "web-sys",
+]
+
+[[package]]
 name = "rgb"
 version = "0.8.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a457e416a0f90d246a4c3288bd7a25b2304ca727f253f95be383dd17af56be8f"
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.16",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustc-demangle"
+version = "0.1.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
 
 [[package]]
 name = "rustc-hash"
@@ -3249,6 +3912,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.23.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0ebcbd2f03de0fc1122ad9bb24b127a5a6cd51d72604a3f3c50ac459762b6cc"
+dependencies = [
+ "once_cell",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "229a4a4c221013e7e1f1a043678c5cc39fe5171437c88fb47151a21e6f5b5c79"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a17884ae0c1b773f1ccd2bd4a8c72f16da897310a98b0e84bf349ad5ead92fc"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3270,12 +3966,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "sandbox"
-version = "0.1.0"
+name = "schannel"
+version = "0.1.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f29ebaa345f945cec9fbbc532eb307f0fdad8161f281b6369539c8d84876b3d"
 dependencies = [
- "renderling",
- "wgpu",
- "winit",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3301,6 +3997,29 @@ dependencies = [
  "memmap2",
  "smithay-client-toolkit",
  "tiny-skia",
+]
+
+[[package]]
+name = "security-framework"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+dependencies = [
+ "bitflags 2.9.1",
+ "core-foundation 0.9.4",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49db231d56a190491cb4aeda9527f1ad45345af50b0851622a7adb8c03b01c32"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -3348,6 +4067,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59fab13f937fa393d08645bf3a84bdfe86e296747b506ada67bb15f10f218b2a"
+dependencies = [
+ "itoa",
+ "serde",
+]
+
+[[package]]
 name = "serde_spanned"
 version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3357,10 +4086,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a4719bff48cee6b39d12c020eeb490953ad2443b7055bd0b21fca26bd8c28b"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "simd-adler32"
@@ -3488,6 +4238,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "socket2"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "233504af464074f9d066d7b5416c5f9b894a5862a6506e306f7b816cdd6f1807"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "spirv"
 version = "0.3.0+sdk-1.3.268.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3526,6 +4286,12 @@ version = "0.9.0"
 source = "git+https://github.com/LegNeato/rust-gpu.git?rev=425328a#425328a3ac7f1f18db914d24b3d4754bf13bb7ac"
 
 [[package]]
+name = "stable_deref_trait"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3556,6 +4322,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
 name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3578,6 +4350,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+]
+
+[[package]]
+name = "system-configuration"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
+dependencies = [
+ "bitflags 2.9.1",
+ "core-foundation 0.9.4",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "system-deps"
 version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3595,6 +4408,19 @@ name = "target-lexicon"
 version = "0.12.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
+
+[[package]]
+name = "tempfile"
+version = "3.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15b61f8f20e3a6f7e0649d825294eaf317edce30f82cf6026e7e4cb9222a7d1e"
+dependencies = [
+ "fastrand 2.3.0",
+ "getrandom 0.3.3",
+ "once_cell",
+ "rustix 1.0.7",
+ "windows-sys 0.60.2",
+]
 
 [[package]]
 name = "termcolor"
@@ -3691,6 +4517,80 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinystr"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d4f6d1145dcb577acf783d4e601bc1d76a13337bb54e6233add580b07344c8b"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
+name = "tokio"
+version = "1.47.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89e49afdadebb872d3145a5638b59eb0691ea23e46ca484037cfab3b76b95038"
+dependencies = [
+ "backtrace",
+ "bytes",
+ "io-uring",
+ "libc",
+ "mio",
+ "parking_lot",
+ "pin-project-lite",
+ "signal-hook-registry",
+ "slab",
+ "socket2",
+ "tokio-macros",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e727b36a1a0e8b74c376ac2211e40c2c8af09fb4013c60d910495810f008e9b"
+dependencies = [
+ "rustls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14307c986784f72ef81c89db7d9e28d6ac26d16213b109ea501696195e6e3ce5"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "toml"
 version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3725,11 +4625,58 @@ dependencies = [
 ]
 
 [[package]]
+name = "tower"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adc82fd73de2a9722ac5da747f12383d2bfdb93591ee6c58486e0097890f05f2"
+dependencies = [
+ "bitflags 2.9.1",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "iri-string",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
+
+[[package]]
 name = "tracing"
 version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -3766,6 +4713,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
 name = "ttf-parser"
 version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3787,6 +4740,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicase"
+version = "2.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b844d17643ee918803943289730bec8aac480150456169e647ed0b576ba539"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3805,10 +4764,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "url"
+version = "2.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32f8b686cadd1473f4bd0117a5d28d36b1ade384ea9b5069a1c40aefed7fda60"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+]
+
+[[package]]
 name = "urlencoding"
 version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "utf8parse"
@@ -3826,6 +4808,12 @@ dependencies = [
  "num-traits",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "vec_map"
@@ -3859,6 +4847,15 @@ checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
 dependencies = [
  "same-file",
  "winapi-util",
+]
+
+[[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
 ]
 
 [[package]]
@@ -3969,6 +4966,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.104",
+]
+
+[[package]]
+name = "wasm-streams"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]
@@ -4374,6 +5384,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
 
 [[package]]
+name = "windows-registry"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b8a9ed28765efc97bbc954883f4e6796c33a06546ebafacbabee9696967499e"
+dependencies = [
+ "windows-link",
+ "windows-result 0.3.4",
+ "windows-strings 0.4.2",
+]
+
+[[package]]
 name = "windows-result"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4759,6 +5780,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "wire-types"
+version = "0.1.0"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "wit-bindgen-rt"
 version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4766,6 +5794,12 @@ checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
 dependencies = [
  "bitflags 2.9.1",
 ]
+
+[[package]]
+name = "writeable"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea2f10b9bb0928dfb1b42b65e1f9e36f7f54dbdf08457afefb38afcdec4fa2bb"
 
 [[package]]
 name = "x11-dl"
@@ -4840,10 +5874,17 @@ checksum = "a62ce76d9b56901b19a74f19431b0d8b3bc7ca4ad685a746dfd78ca8f4fc6bda"
 name = "xtask"
 version = "0.1.0"
 dependencies = [
+ "axum",
  "clap 4.5.40",
  "env_logger",
+ "image 0.25.6",
+ "img-diff",
  "log",
+ "new_mime_guess",
  "renderling_build",
+ "reqwest",
+ "tokio",
+ "wire-types",
 ]
 
 [[package]]
@@ -4864,6 +5905,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "yoke"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f41bb01b8226ef4bfd589436a297c53d118f65921786300e427be8d487695cc"
+dependencies = [
+ "serde",
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38da3c9736e16c5d3c8c597a9aaa5d1fa565d0532ae05e27c24aa62fb32c0ab6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+ "synstructure",
+]
+
+[[package]]
 name = "zerocopy"
 version = "0.8.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4877,6 +5942,66 @@ name = "zerocopy-derive"
 version = "0.8.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+ "synstructure",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
+
+[[package]]
+name = "zerotrie"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36f0bbd478583f79edad978b407914f61b2972f5af6fa089686016be8f9af595"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7aa2bd55086f1ab526693ecbe444205da57e25f4489879da80635a46d90e73b"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b96237efa0c878c64bd89c436f661be4e46b2f3eff1ebb976f7ef2321d2f58f"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,8 @@ members = [
     "crates/loading-bytes",
     "crates/renderling", 
     "crates/renderling-build",
-    "crates/sandbox",
+    "crates/wire-types",
+    # "crates/sandbox",
     "crates/xtask"
 ]
 
@@ -17,6 +18,7 @@ resolver = "2"
 [workspace.dependencies]
 assert_approx_eq = "1.1.0"
 async-channel = "1.8"
+axum = "0.8.4"
 bytemuck = { version = "1.19.0", features = ["derive"] }
 cfg_aliases = "0.2"
 clap = { version = "4.5.23", features = ["derive"] }
@@ -35,9 +37,11 @@ log = "0.4"
 loading-bytes = { path = "crates/loading-bytes", version = "0.1.1" }
 lyon = "1.0.1"
 naga = { version = "26.0", features = ["spv-in", "wgsl-out", "wgsl-in", "msl-out"] }
+new_mime_guess = "4.0.4"
 pretty_assertions = "1.4.0"
 proc-macro2 = { version = "1.0", features = ["span-locations"] }
 quote = "1.0"
+reqwest = "0.12.23"
 rustc-hash = "1.1"
 serde = {version = "1.0", features = ["derive"]}
 serde_json = "1.0.117"
@@ -47,9 +51,11 @@ snafu = "0.8"
 spirv-std = { git = "https://github.com/LegNeato/rust-gpu.git", rev = "425328a" }
 spirv-std-macros = { git = "https://github.com/LegNeato/rust-gpu.git", rev = "425328a" }
 syn = { version = "2.0.49", features = ["full", "extra-traits", "parsing"] }
+tokio = "1.47.1"
 tracing = "0.1.41"
 wasm-bindgen = "0.2"
 wasm-bindgen-futures = "0.4"
+wasm-bindgen-test = "0.3"
 web-sys = "0.3"
 winit = { version = "0.30" }
 wgpu = { version = "26.0" }

--- a/crates/example-wasm/Cargo.toml
+++ b/crates/example-wasm/Cargo.toml
@@ -13,12 +13,13 @@ console_log = "^0.2"
 console_error_panic_hook = "^0.1"
 example = { path = "../example" }
 fern = "0.6"
-futures-lite = { workspace = true }
-gltf = { workspace = true }
-log = { workspace = true }
-renderling = { path = "../renderling", features = ["wasm"] }
-wasm-bindgen = { workspace = true }
-wasm-bindgen-futures = { workspace = true }
+futures-lite.workspace = true
+gltf.workspace = true
+log.workspace = true
+renderling = { path = "../renderling", features = ["wasm", "winit"] }
+wasm-bindgen.workspace = true
+wasm-bindgen-futures.workspace = true
 wasm-bindgen-test = "^0.3"
 web-sys = { workspace = true, features = ["Document", "Element", "Event", "HtmlCanvasElement", "HtmlElement", "Window"] }
-wgpu = { workspace = true }
+wgpu.workspace = true
+winit.workspace = true

--- a/crates/example-wasm/index.html
+++ b/crates/example-wasm/index.html
@@ -63,6 +63,10 @@
         margin: 0 0.25em 0.5em 0.25em;
       }
     </style>
+
+    <link data-trunk rel="copy-file" href="../../gltf/Fox.glb" />
+    <link data-trunk rel="copy-file" href="../../img/hdr/helipad.hdr" />
+    <link data-trunk rel="copy-file" href="../../fonts/Recursive Mn Lnr St Med Nerd Font Complete.ttf" />
   </head>
   <body>
     <main>

--- a/crates/example-wasm/src/event.rs
+++ b/crates/example-wasm/src/event.rs
@@ -31,7 +31,6 @@ impl Drop for WebCallback {
                         closure.as_ref().unchecked_ref(),
                     )
                     .unwrap();
-                log::trace!("dropping event {}", self.name);
             }
         }
     }

--- a/crates/example-wasm/src/lib.rs
+++ b/crates/example-wasm/src/lib.rs
@@ -1,9 +1,14 @@
 use futures_lite::StreamExt;
-use renderling::Context;
+use glam::{Vec2, Vec3, Vec4};
+use renderling::{prelude::*, ui::prelude::*};
 use wasm_bindgen::prelude::*;
 use web_sys::HtmlCanvasElement;
 
 mod event;
+mod req_animation_frame;
+
+// const HDR_IMAGE_BYTES: &[u8] = include_bytes!("../../../img/hdr/helipad.hdr");
+// const GLTF_FOX_BYTES: &[u8] = include_bytes!("../../../gltf/Fox.glb");
 
 fn surface_from_canvas(_canvas: HtmlCanvasElement) -> Option<wgpu::SurfaceTarget<'static>> {
     #[cfg(target_arch = "wasm32")]
@@ -16,14 +21,58 @@ fn surface_from_canvas(_canvas: HtmlCanvasElement) -> Option<wgpu::SurfaceTarget
     }
 }
 
+pub struct App {
+    ctx: Context,
+    ui: Ui,
+    path: UiPath,
+    // stage: Stage,
+    // doc: GltfDocument,
+    // camera: Hybrid<Camera>,
+    // text: UiText,
+}
+
+impl App {
+    fn tick(&self) {
+        let frame = self.ctx.get_next_frame().unwrap();
+        self.ui.render(&frame.view());
+        // // self.stage.render(&frame.view());
+        // let mut encoder = self
+        //     .ctx
+        //     .get_device()
+        //     .create_command_encoder(&Default::default());
+        // {
+        //     let mut render_pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+        //         color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+        //             view: &frame.view(),
+        //             depth_slice: None,
+        //             resolve_target: None,
+        //             ops: wgpu::Operations {
+        //                 load: wgpu::LoadOp::Clear(wgpu::Color::RED),
+        //                 store: wgpu::StoreOp::Store,
+        //             },
+        //         })],
+        //         depth_stencil_attachment: None,
+        //         ..Default::default()
+        //     });
+        //     render_pass.
+        // }
+
+        frame.present();
+        self.ctx
+            .get_device()
+            .poll(wgpu::PollType::Wait)
+            .expect_throw("Error polling");
+    }
+}
+
 #[wasm_bindgen(start)]
 pub async fn main() {
     std::panic::set_hook(Box::new(console_error_panic_hook::hook));
     fern::Dispatch::new()
-        .level(log::LevelFilter::Trace)
-        .level_for("wgpu", log::LevelFilter::Error)
-        .level_for("naga", log::LevelFilter::Error)
-        .level_for("renderling", log::LevelFilter::Debug)
+        .level(log::LevelFilter::Info)
+        .level_for("wgpu", log::LevelFilter::Warn)
+        .level_for("naga", log::LevelFilter::Trace)
+        .level_for("renderling::draw", log::LevelFilter::Trace)
         .chain(fern::Output::call(console_log::log))
         .apply()
         .unwrap();
@@ -31,32 +80,80 @@ pub async fn main() {
     log::info!("Starting example-wasm");
 
     let dom_window = web_sys::window().unwrap();
-    let ww = dom_window.inner_width().unwrap().as_f64().unwrap() as u32;
-    let wh = dom_window.inner_height().unwrap().as_f64().unwrap() as u32;
     let dom_doc = dom_window.document().unwrap();
 
-    let viewport_canvas = dom_doc
+    let canvas = dom_doc
         .query_selector("main canvas")
         .unwrap()
         .unwrap()
         .dyn_into::<HtmlCanvasElement>()
         .unwrap();
-    viewport_canvas.set_width(ww);
-    viewport_canvas.set_height(wh);
+    canvas.set_width(800);
+    canvas.set_height(600);
 
-    let surface = surface_from_canvas(viewport_canvas.clone()).unwrap();
-    let ctx = Context::try_from_raw_window(ww, wh, None, surface)
+    let surface = surface_from_canvas(canvas.clone()).unwrap();
+    let ctx = Context::try_new_with_surface(800, 600, None, surface)
         .await
         .unwrap();
-    let app = example::App::new(&ctx, example::camera::CameraControl::Turntable);
 
-    let window_resize = event::event_stream("resize", &dom_window);
-    let mut all_events = window_resize;
+    let ui = ctx.new_ui();
+    let path = ui
+        .new_path()
+        .with_circle(Vec2::splat(100.0), 20.0)
+        .with_fill_color(Vec4::new(1.0, 1.0, 0.0, 1.0))
+        .fill();
+    // let _ = ui
+    //     .load_font("Recursive Mn Lnr St Med Nerd Font Complete.ttf")
+    //     .await
+    //     .expect_throw("Could not load font");
+    // let text = ui
+    //     .new_text()
+    //     .with_color(
+    //         // white
+    //         Vec4::ONE,
+    //     )
+    //     .with_section(Section::default().add_text(Text::new("WASM example").with_scale(24.0)))
+    //     .build();
 
-    while let Some(event) = all_events.next().await {
-        log::trace!("event: {event:#?}");
-        let frame = ctx.get_next_frame().unwrap();
-        app.stage.render(&frame.view());
-        frame.present();
+    // let stage = ctx
+    //     .new_stage()
+    //     .with_background_color(
+    //         // black
+    //         // Vec3::ZERO.extend(1.0),
+    //         Vec4::new(1.0, 0.0, 0.0, 1.0),
+    //     )
+    //     .with_lighting(false);
+
+    // let skybox = stage.new_skybox_from_bytes(HDR_IMAGE_BYTES).unwrap();
+    // stage.set_skybox(skybox);
+
+    // let fox = stage.load_gltf_document_from_bytes(GLTF_FOX_BYTES).unwrap();
+    // log::info!("fox aabb: {:?}", fox.bounding_volume());
+
+    // let camera = stage.new_camera(Camera::default_perspective(800.0, 600.0));
+
+    let app = App {
+        ctx,
+        ui,
+        path,
+        // stage,
+        // doc: fox,
+        // camera,
+        // text,
+    };
+    app.tick();
+
+    // let mut app = example::App::new(&ctx, example::camera::CameraControl::Turntable);
+    // app.load_hdr_skybox(HDR_IMAGE_BYTES.to_vec());
+    // app.load_default_model();
+    // app.tick();
+    // app.render(&ctx);
+
+    // let window_resize = event::event_stream("resize", &dom_window);
+    // let mut all_events = window_resize;
+
+    loop {
+        let _ = req_animation_frame::next_animation_frame().await;
+        app.tick();
     }
 }

--- a/crates/example-wasm/src/req_animation_frame.rs
+++ b/crates/example-wasm/src/req_animation_frame.rs
@@ -1,0 +1,80 @@
+//! Request animation frame helpers, taken from [mogwai](https://crates.io/crates/mogwai).
+use std::{cell::RefCell, rc::Rc};
+
+use wasm_bindgen::{prelude::Closure, JsCast, JsValue, UnwrapThrowExt};
+
+fn req_animation_frame(f: &Closure<dyn FnMut(JsValue)>) {
+    web_sys::window()
+        .expect_throw("could not get window")
+        .request_animation_frame(f.as_ref().unchecked_ref())
+        .expect_throw("should register `requestAnimationFrame` OK");
+}
+
+/// Sets a static rust closure to be called with `window.requestAnimationFrame`.
+///
+/// The static rust closure takes one parameter which is
+/// a timestamp representing the number of milliseconds since the application's
+/// load. See <https://developer.mozilla.org/en-US/docs/Web/API/DOMHighResTimeStamp>
+/// for more info.
+fn request_animation_frame(mut f: impl FnMut(JsValue) + 'static) {
+    let wrapper = Rc::new(RefCell::new(None));
+    let callback = Box::new({
+        let wrapper = wrapper.clone();
+        move |jsval| {
+            f(jsval);
+            wrapper.borrow_mut().take();
+        }
+    }) as Box<dyn FnMut(JsValue)>;
+    let closure: Closure<dyn FnMut(JsValue)> = Closure::wrap(callback);
+    *wrapper.borrow_mut() = Some(closure);
+    req_animation_frame(wrapper.borrow().as_ref().unwrap_throw());
+}
+
+#[derive(Clone, Default)]
+#[expect(clippy::type_complexity, reason = "not too complex")]
+struct NextFrame {
+    closure: Rc<RefCell<Option<Closure<dyn FnMut(JsValue)>>>>,
+    ts: Rc<RefCell<Option<f64>>>,
+    waker: Rc<RefCell<Option<std::task::Waker>>>,
+}
+
+impl std::future::Future for NextFrame {
+    type Output = f64;
+
+    fn poll(
+        self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Self::Output> {
+        if let Some(ts) = self.ts.borrow_mut().take() {
+            std::task::Poll::Ready(ts)
+        } else {
+            *self.waker.borrow_mut() = Some(cx.waker().clone());
+            std::task::Poll::Pending
+        }
+    }
+}
+
+/// Creates a future that will resolve on the next animation frame.
+///
+/// The future's output is a timestamp representing the number of
+/// milliseconds since the application's load.
+/// See <https://developer.mozilla.org/en-US/docs/Web/API/DOMHighResTimeStamp>
+/// for more info.
+pub fn next_animation_frame() -> impl std::future::Future<Output = f64> {
+    // https://rustwasm.github.io/wasm-bindgen/examples/request-animation-frame.html#srclibrs
+    let frame = NextFrame::default();
+
+    *frame.closure.borrow_mut() = Some(Closure::wrap(Box::new({
+        let frame = frame.clone();
+        move |ts_val: JsValue| {
+            *frame.ts.borrow_mut() = Some(ts_val.as_f64().unwrap_or(0.0));
+            if let Some(waker) = frame.waker.borrow_mut().take() {
+                waker.wake();
+            }
+        }
+    }) as Box<dyn FnMut(JsValue)>));
+
+    req_animation_frame(frame.closure.borrow().as_ref().unwrap_throw());
+
+    frame
+}

--- a/crates/example/src/camera.rs
+++ b/crates/example/src/camera.rs
@@ -2,11 +2,8 @@
 use std::str::FromStr;
 
 use craballoc::prelude::Hybrid;
-use renderling::{
-    bvol::Aabb,
-    camera::Camera,
-    math::{Mat4, Quat, UVec2, Vec2, Vec3},
-};
+use renderling::prelude::glam::{Mat4, Quat, UVec2, Vec2, Vec3};
+use renderling::{bvol::Aabb, camera::Camera};
 use winit::{event::KeyEvent, keyboard::Key};
 
 const RADIUS_SCROLL_DAMPENING: f32 = 0.001;
@@ -198,8 +195,12 @@ impl CameraController for WasdMouseCameraController {
     }
 
     fn update_camera(&self, UVec2 { x: w, y: h }: UVec2, camera: &Hybrid<Camera>) {
-        let camera_rotation =
-            Quat::from_euler(renderling::math::EulerRot::XYZ, self.phi, self.theta, 0.0);
+        let camera_rotation = Quat::from_euler(
+            renderling::prelude::glam::EulerRot::XYZ,
+            self.phi,
+            self.theta,
+            0.0,
+        );
         let projection =
             Mat4::perspective_infinite_rh(std::f32::consts::FRAC_PI_4, w as f32 / h as f32, 0.01);
         let view = Mat4::from_quat(camera_rotation) * Mat4::from_translation(-self.position);

--- a/crates/example/src/lib.rs
+++ b/crates/example/src/lib.rs
@@ -6,12 +6,13 @@ use std::{
 };
 
 use craballoc::prelude::{GpuArray, Hybrid};
+use glam::{Mat4, UVec2, Vec2, Vec3, Vec4};
 use renderling::{
     atlas::AtlasImage,
     bvol::{Aabb, BoundingSphere},
     camera::Camera,
     light::{AnalyticalLight, DirectionalLightDescriptor},
-    math::{Mat4, UVec2, Vec2, Vec3, Vec4},
+    prelude::*,
     skybox::Skybox,
     stage::{Animator, GltfDocument, Renderlet, Stage, Vertex},
     ui::{FontArc, Section, Text, Ui, UiPath, UiText},
@@ -201,10 +202,12 @@ impl App {
     }
 
     pub fn render(&self, ctx: &Context) {
+        log::info!("render");
         let frame = ctx.get_next_frame().unwrap();
         self.stage.render(&frame.view());
         self.ui.ui.render(&frame.view());
         frame.present();
+        log::info!("render done");
     }
 
     pub fn update_view(&mut self) {
@@ -212,7 +215,8 @@ impl App {
             .update_camera(self.stage.get_size(), &self.camera);
     }
 
-    fn load_hdr_skybox(&mut self, bytes: Vec<u8>) {
+    pub fn load_hdr_skybox(&mut self, bytes: Vec<u8>) {
+        log::info!("loading skybox");
         let img = AtlasImage::from_hdr_bytes(&bytes).unwrap();
         let skybox = Skybox::new(self.stage.runtime(), img);
         self.skybox_image_bytes = Some(bytes);
@@ -220,6 +224,7 @@ impl App {
     }
 
     pub fn load_default_model(&mut self) {
+        log::info!("loading default model");
         let mut min = Vec3::splat(f32::INFINITY);
         let mut max = Vec3::splat(f32::NEG_INFINITY);
 

--- a/crates/example/src/main.rs
+++ b/crates/example/src/main.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use clap::Parser;
 use example::{camera::CameraControl, App};
 use renderling::{
-    math::{UVec2, Vec2},
+    prelude::glam::{UVec2, Vec2},
     Context,
 };
 use winit::{application::ApplicationHandler, event::WindowEvent, window::WindowAttributes};
@@ -86,7 +86,7 @@ impl ApplicationHandler for OuterApp {
         let window = Arc::new(event_loop.create_window(attributes).unwrap());
 
         // Set up a new renderling context
-        let ctx = Context::try_from_window(None, window.clone()).unwrap();
+        let ctx = futures_lite::future::block_on(Context::from_winit_window(None, window.clone()));
         let mut app = App::new(&ctx, self.cli.camera_control);
         if let Some(file) = self.cli.model.as_ref() {
             log::info!("loading model '{file}'");

--- a/crates/example/src/utils.rs
+++ b/crates/example/src/utils.rs
@@ -73,7 +73,7 @@ impl<T: TestAppHandler> winit::application::ApplicationHandler for TestApp<T> {
                 )
                 .unwrap(),
         );
-        let ctx = Context::try_from_window(None, window.clone()).unwrap();
+        let ctx = futures_lite::future::block_on(Context::from_winit_window(None, window.clone()));
         let mut app = T::new(event_loop, window, &ctx);
         app.resumed(event_loop);
         self.inner = Some(InnerTestApp { app, ctx });

--- a/crates/loading-bytes/Cargo.toml
+++ b/crates/loading-bytes/Cargo.toml
@@ -15,6 +15,8 @@ readme = "README.md"
 async-fs = "1.6"
 js-sys = "0.3"
 send_wrapper = {workspace=true}
+serde.workspace = true
+serde_json.workspace = true
 snafu = {workspace = true}
 wasm-bindgen = {workspace = true}
 wasm-bindgen-futures = {workspace = true}

--- a/crates/loading-bytes/src/lib.rs
+++ b/crates/loading-bytes/src/lib.rs
@@ -1,14 +1,49 @@
 //! Abstraction over loading bytes on WASM or other.
 use snafu::prelude::*;
+use wasm_bindgen::UnwrapThrowExt;
+
+#[derive(Debug, Snafu)]
+pub enum WasmError {
+    #[snafu(display("Could not create request to load '{path}': {msg:#?}"))]
+    CreateRequest {
+        path: String,
+        msg: send_wrapper::SendWrapper<wasm_bindgen::JsValue>,
+    },
+
+    #[snafu(display("Fetch failed to load '{path}' by WASM error: {msg:#?}"))]
+    Fetch {
+        path: String,
+        msg: send_wrapper::SendWrapper<wasm_bindgen::JsValue>,
+    },
+
+    #[snafu(display("Fetching '{path}' returned something that was not a Response: {msg:#?}"))]
+    NotAResponse {
+        path: String,
+        msg: send_wrapper::SendWrapper<wasm_bindgen::JsValue>,
+    },
+
+    #[snafu(display("Could not get response array buffer '{path}': {msg:#?}"))]
+    Array {
+        path: String,
+        msg: send_wrapper::SendWrapper<wasm_bindgen::JsValue>,
+    },
+
+    #[snafu(display("Could not get buffer from array '{path}': {msg:#?}"))]
+    Buffer {
+        path: String,
+        msg: send_wrapper::SendWrapper<wasm_bindgen::JsValue>,
+    },
+
+    #[snafu(display("{other}"))]
+    Other { other: String },
+}
 
 /// Enumeration of all errors this library may result in.
 #[derive(Debug, Snafu)]
 pub enum LoadingBytesError {
-    #[snafu(display("loading '{path}' by WASM error: {msg:#?}"))]
-    Wasm {
-        path: String,
-        msg: send_wrapper::SendWrapper<wasm_bindgen::JsValue>,
-    },
+    #[snafu(display("{source}"))]
+    Wasm { source: WasmError },
+
     #[snafu(display("loading '{path}' by filesystem from CWD '{}' error: {source}", cwd.display()))]
     Fs {
         path: String,
@@ -17,50 +52,135 @@ pub enum LoadingBytesError {
     },
 }
 
+impl From<WasmError> for LoadingBytesError {
+    fn from(value: WasmError) -> Self {
+        LoadingBytesError::Wasm { source: value }
+    }
+}
+
+pub async fn load_wasm(path: &str) -> Result<Vec<u8>, WasmError> {
+    use wasm_bindgen::JsCast;
+
+    let path = path.to_string();
+    let opts = web_sys::RequestInit::new();
+    opts.set_method("GET");
+    let request = web_sys::Request::new_with_str_and_init(&path, &opts).map_err(|msg| {
+        CreateRequestSnafu {
+            path: path.clone(),
+            msg: send_wrapper::SendWrapper::new(msg),
+        }
+        .build()
+    })?;
+    let window = web_sys::window().unwrap();
+    let resp_value = wasm_bindgen_futures::JsFuture::from(window.fetch_with_request(&request))
+        .await
+        .map_err(|msg| {
+            FetchSnafu {
+                path: path.clone(),
+                msg: send_wrapper::SendWrapper::new(msg),
+            }
+            .build()
+        })?;
+    let resp: web_sys::Response = resp_value.dyn_into().map_err(|msg| {
+        NotAResponseSnafu {
+            path: path.clone(),
+            msg: send_wrapper::SendWrapper::new(msg),
+        }
+        .build()
+    })?;
+    let array_promise = resp.array_buffer().map_err(|msg| {
+        ArraySnafu {
+            path: path.clone(),
+            msg: send_wrapper::SendWrapper::new(msg),
+        }
+        .build()
+    })?;
+    let buffer = wasm_bindgen_futures::JsFuture::from(array_promise)
+        .await
+        .map_err(|msg| {
+            BufferSnafu {
+                path: path.clone(),
+                msg: send_wrapper::SendWrapper::new(msg),
+            }
+            .build()
+        })?;
+    assert!(buffer.is_instance_of::<js_sys::ArrayBuffer>());
+    let array: js_sys::Uint8Array = js_sys::Uint8Array::new(&buffer);
+    let mut bytes: Vec<u8> = vec![0; array.length() as usize];
+    array.copy_to(&mut bytes);
+    Ok(bytes)
+}
+
+pub async fn post_json_wasm<T: serde::de::DeserializeOwned>(
+    path: &str,
+    data: &str,
+) -> Result<T, WasmError> {
+    use js_sys::JsString;
+    use wasm_bindgen::JsCast;
+
+    let path = path.to_string();
+    let opts = web_sys::RequestInit::new();
+    opts.set_method("POST");
+    let headers = js_sys::Object::new();
+    js_sys::Reflect::set(
+        &headers,
+        &JsString::from("content-type"),
+        &JsString::from("application/json"),
+    )
+    .unwrap();
+    opts.set_headers(&headers);
+    let body = js_sys::JsString::from(data);
+    opts.set_body(&body.into());
+    let request = web_sys::Request::new_with_str_and_init(&path, &opts).map_err(|msg| {
+        CreateRequestSnafu {
+            path: path.clone(),
+            msg: send_wrapper::SendWrapper::new(msg),
+        }
+        .build()
+    })?;
+    let window = web_sys::window().unwrap();
+    let resp_value = wasm_bindgen_futures::JsFuture::from(window.fetch_with_request(&request))
+        .await
+        .map_err(|msg| {
+            FetchSnafu {
+                path: path.clone(),
+                msg: send_wrapper::SendWrapper::new(msg),
+            }
+            .build()
+        })?;
+    let resp: web_sys::Response = resp_value.dyn_into().map_err(|msg| {
+        NotAResponseSnafu {
+            path: path.clone(),
+            msg: send_wrapper::SendWrapper::new(msg),
+        }
+        .build()
+    })?;
+
+    snafu::ensure!(
+        resp.ok(),
+        OtherSnafu {
+            other: wasm_bindgen_futures::JsFuture::from(resp.text().unwrap())
+                .await
+                .unwrap()
+                .as_string()
+                .unwrap()
+        }
+    );
+
+    let value = wasm_bindgen_futures::JsFuture::from(resp.text().unwrap_throw())
+        .await
+        .unwrap_throw();
+    let s = value.as_string().expect_throw(&format!("{value:#?}"));
+    let t = serde_json::from_str::<T>(&s).unwrap_throw();
+    Ok(t)
+}
+
 /// Load the file at the given url fragment or path and return it as a vector of bytes, if
 /// possible.
 pub async fn load(path: &str) -> Result<Vec<u8>, LoadingBytesError> {
     #[cfg(target_arch = "wasm32")]
     {
-        use wasm_bindgen::JsCast;
-
-        let path = path.to_string();
-        let mut opts = web_sys::RequestInit::new();
-        opts.method("GET");
-        let request = web_sys::Request::new_with_str_and_init(&path, &opts).map_err(|msg| {
-            LoadingBytesError::Wasm {
-                path: path.clone(),
-                msg: send_wrapper::SendWrapper::new(msg),
-            }
-        })?;
-        let window = web_sys::window().unwrap();
-        let resp_value = wasm_bindgen_futures::JsFuture::from(window.fetch_with_request(&request))
-            .await
-            .map_err(|msg| LoadingBytesError::Wasm {
-                path: path.clone(),
-                msg: send_wrapper::SendWrapper::new(msg),
-            })?;
-        let resp: web_sys::Response =
-            resp_value
-                .dyn_into()
-                .map_err(|msg| LoadingBytesError::Wasm {
-                    path: path.clone(),
-                    msg: send_wrapper::SendWrapper::new(msg),
-                })?;
-        let array_promise = resp.array_buffer().map_err(|msg| LoadingBytesError::Wasm {
-            path: path.clone(),
-            msg: send_wrapper::SendWrapper::new(msg),
-        })?;
-        let buffer = wasm_bindgen_futures::JsFuture::from(array_promise)
-            .await
-            .map_err(|msg| LoadingBytesError::Wasm {
-                path: path.clone(),
-                msg: send_wrapper::SendWrapper::new(msg),
-            })?;
-        assert!(buffer.is_instance_of::<js_sys::ArrayBuffer>());
-        let array: js_sys::Uint8Array = js_sys::Uint8Array::new(&buffer);
-        let mut bytes: Vec<u8> = vec![0; array.length() as usize];
-        array.copy_to(&mut bytes);
+        let bytes = load_wasm(path).await?;
         Ok(bytes)
     }
     #[cfg(not(target_arch = "wasm32"))]

--- a/crates/renderling/Cargo.toml
+++ b/crates/renderling/Cargo.toml
@@ -30,6 +30,7 @@ ui = ["dep:glyph_brush", "dep:loading-bytes", "dep:lyon"]
 wasm = ["wgpu/fragile-send-sync-non-atomic-wasm"]
 debug-slab = []
 light-tiling-stats = [ "dep:plotters" ]
+test-helpers = []
 
 [build-dependencies]
 cfg_aliases.workspace = true
@@ -86,8 +87,12 @@ icosahedron = "0.1"
 img-diff = { path = "../img-diff" }
 naga.workspace = true
 ttf-parser = "0.20.0"
+wasm-bindgen.workspace = true
+wasm-bindgen-test.workspace = true
+web-sys.workspace = true
 wgpu-core.workspace = true
 winit.workspace = true
+wire-types = { path = "../wire-types" }
 
 [target.'cfg(not(target_arch = "spirv"))'.dev-dependencies]
 glam = { workspace = true, features = ["std", "debug-glam-assert"] }

--- a/crates/renderling/Cargo.toml
+++ b/crates/renderling/Cargo.toml
@@ -59,7 +59,6 @@ craballoc.workspace = true
 crabslab = { workspace = true, features = ["default"] }
 dagga = {workspace=true}
 crunch = "0.5"
-futures-lite = {workspace=true}
 glam = { workspace = true, features = ["std"] }
 gltf = {workspace = true, optional = true}
 glyph_brush = {workspace = true, optional = true}
@@ -82,6 +81,7 @@ ctor = "0.2.2"
 env_logger.workspace = true
 example = { path = "../example" }
 fastrand = "2.1.1"
+futures-lite.workspace = true
 human-repr = "1.1.0"
 icosahedron = "0.1"
 img-diff = { path = "../img-diff" }

--- a/crates/renderling/src/bloom/cpu.rs
+++ b/crates/renderling/src/bloom/cpu.rs
@@ -701,7 +701,7 @@ impl Bloom {
 mod test {
     use glam::Vec3;
 
-    use crate::{camera::Camera, Context};
+    use crate::{camera::Camera, test::BlockOnFuture, Context};
 
     use super::*;
 
@@ -747,7 +747,7 @@ mod test {
     fn bloom_sanity() {
         let width = 256;
         let height = 128;
-        let ctx = Context::headless(width, height);
+        let ctx = Context::headless(width, height).block();
         let stage = ctx.new_stage().with_bloom(false);
         // .with_frustum_culling(false)
         // .with_occlusion_culling(false);
@@ -766,7 +766,7 @@ mod test {
 
         let frame = ctx.get_next_frame().unwrap();
         stage.render(&frame.view());
-        let img = frame.read_image().unwrap();
+        let img = frame.read_image().block().unwrap();
         img_diff::assert_img_eq("bloom/without.png", img);
         frame.present();
 
@@ -776,7 +776,7 @@ mod test {
         stage.set_bloom_filter_radius(2.0);
         let frame = ctx.get_next_frame().unwrap();
         stage.render(&frame.view());
-        let img = frame.read_image().unwrap();
+        let img = frame.read_image().block().unwrap();
         img_diff::assert_img_eq("bloom/with.png", img);
     }
 }

--- a/crates/renderling/src/bvol.rs
+++ b/crates/renderling/src/bvol.rs
@@ -141,6 +141,14 @@ impl Aabb {
         self.min == self.max
     }
 
+    /// Returns the union of the two [`Aabbs`].
+    pub fn union(a: Self, b: Self) -> Self {
+        Aabb {
+            min: a.min.min(a.max).min(b.min).min(b.max),
+            max: a.max.max(a.min).max(b.max).max(b.min),
+        }
+    }
+
     /// Determines whether this `Aabb` can be seen by `camera` after being
     /// transformed by `transform`.
     pub fn is_outside_camera_view(&self, camera: &Camera, transform: Transform) -> bool {
@@ -719,5 +727,19 @@ mod test {
         let b = Aabb::new(Vec3::splat(0.9), Vec3::splat(1.9));
         assert!(a.intersects_aabb(&b));
         assert!(b.intersects_aabb(&a));
+    }
+
+    #[test]
+    fn aabb_union() {
+        let a = Aabb::new(Vec3::splat(4.0), Vec3::splat(5.0));
+        let b = Aabb::new(Vec3::ZERO, Vec3::ONE);
+        let c = Aabb::union(a, b);
+        assert_eq!(
+            Aabb {
+                min: Vec3::ZERO,
+                max: Vec3::splat(5.0)
+            },
+            c
+        );
     }
 }

--- a/crates/renderling/src/bvol.rs
+++ b/crates/renderling/src/bvol.rs
@@ -595,7 +595,7 @@ impl BVol for Aabb {
 mod test {
     use glam::{Mat4, Quat};
 
-    use crate::{pbr::Material, stage::Vertex, Context};
+    use crate::{pbr::Material, stage::Vertex, test::BlockOnFuture, Context};
 
     use super::*;
 
@@ -649,7 +649,7 @@ mod test {
 
     #[test]
     fn bounding_box_from_min_max() {
-        let ctx = Context::headless(256, 256);
+        let ctx = Context::headless(256, 256).block();
         let stage = ctx
             .new_stage()
             .with_background_color(Vec4::ZERO)
@@ -717,7 +717,7 @@ mod test {
 
         let frame = ctx.get_next_frame().unwrap();
         stage.render(&frame.view());
-        let img = frame.read_image().unwrap();
+        let img = frame.read_image().block().unwrap();
         img_diff::assert_img_eq("bvol/bounding_box/get_mesh.png", img);
     }
 

--- a/crates/renderling/src/cubemap/cpu.rs
+++ b/crates/renderling/src/cubemap/cpu.rs
@@ -272,6 +272,7 @@ mod test {
     use crate::{
         math::{UNIT_INDICES, UNIT_POINTS},
         stage::Vertex,
+        test::BlockOnFuture,
     };
 
     use super::*;
@@ -280,7 +281,7 @@ mod test {
     fn hand_rolled_cubemap_sampling() {
         let width = 256;
         let height = 256;
-        let ctx = crate::Context::headless(width, height);
+        let ctx = crate::Context::headless(width, height).block();
         let stage = ctx
             .new_stage()
             .with_background_color(Vec4::ZERO)
@@ -306,7 +307,7 @@ mod test {
 
         let frame = ctx.get_next_frame().unwrap();
         stage.render(&frame.view());
-        let img = frame.read_image().unwrap();
+        let img = frame.read_image().block().unwrap();
         img_diff::assert_img_eq("cubemap/hand_rolled_cubemap_sampling/cube.png", img);
         frame.present();
 
@@ -487,6 +488,7 @@ mod test {
 
             let img = Texture::read(&ctx, &render_target, 1, 1, 4, 1)
                 .into_image::<u8, image::Rgba<u8>>(ctx.get_device())
+                .block()
                 .unwrap();
             let image::Rgba([r, g, b, a]) = img.get_pixel(0, 0);
             Vec4::new(
@@ -522,6 +524,7 @@ mod test {
                 Some(wgpu::Origin3d { x: 0, y: 0, z: i }),
             )
             .into_image::<u8, image::Rgba<u8>>(ctx.get_device())
+            .block()
             .unwrap();
 
             img_diff::assert_img_eq(

--- a/crates/renderling/src/cull/cpu.rs
+++ b/crates/renderling/src/cull/cpu.rs
@@ -262,7 +262,7 @@ impl DepthPyramid {
     }
 
     pub fn resize(&mut self, size: UVec2) {
-        log::info!("resizing depth pyramid to {size}");
+        log::trace!("resizing depth pyramid to {size}");
         // drop the buffers
         let mip = self.slab.new_array(vec![]);
         self.mip_data = vec![];
@@ -303,8 +303,8 @@ impl DepthPyramid {
                     crate::color::f32_to_u8(depth)
                 })
                 .collect();
-            log::info!("min: {min}");
-            log::info!("max: {max}");
+            log::trace!("min: {min}");
+            log::trace!("max: {max}");
             let width = size.x >> i;
             let height = size.y >> i;
             let image = image::GrayImage::from_raw(width, height, depth_data)
@@ -329,12 +329,12 @@ impl ComputeCopyDepth {
 
     fn create_bindgroup_layout(device: &wgpu::Device, sample_count: u32) -> wgpu::BindGroupLayout {
         if sample_count > 1 {
-            log::info!(
+            log::trace!(
                 "creating bindgroup layout with {sample_count} multisampled depth for {}",
                 Self::LABEL.unwrap()
             );
         } else {
-            log::info!(
+            log::trace!(
                 "creating bindgroup layout without multisampling for {}",
                 Self::LABEL.unwrap()
             );
@@ -374,10 +374,10 @@ impl ComputeCopyDepth {
         multisampled: bool,
     ) -> wgpu::ComputePipeline {
         let linkage = if multisampled {
-            log::info!("creating multisampled shader for {}", Self::LABEL.unwrap());
+            log::trace!("creating multisampled shader for {}", Self::LABEL.unwrap());
             crate::linkage::compute_copy_depth_to_pyramid_multisampled::linkage(device)
         } else {
-            log::info!(
+            log::trace!(
                 "creating shader without multisampling for {}",
                 Self::LABEL.unwrap()
             );

--- a/crates/renderling/src/draw/cpu.rs
+++ b/crates/renderling/src/draw/cpu.rs
@@ -168,6 +168,8 @@ impl DrawCalls {
         stage_slab_buffer: &SlabBuffer<wgpu::Buffer>,
         depth_texture: &Texture,
     ) -> Self {
+        let supported_features = ctx.get_adapter().features();
+        log::trace!("supported features: {supported_features:#?}");
         let can_use_multi_draw_indirect = ctx.get_adapter().features().contains(
             wgpu::Features::INDIRECT_FIRST_INSTANCE | wgpu::Features::MULTI_DRAW_INDIRECT,
         );
@@ -330,6 +332,9 @@ impl DrawCalls {
 
     /// Draw into the given `RenderPass` by directly calling each draw.
     pub fn draw_direct(&self, render_pass: &mut wgpu::RenderPass) {
+        if self.internal_renderlets.is_empty() {
+            log::warn!("no internal renderlets, nothing to draw");
+        }
         for ir in self.internal_renderlets.iter() {
             // UNWRAP: panic on purpose
             if let Some(hr) = ir.inner.upgrade() {
@@ -362,6 +367,8 @@ impl DrawCalls {
                 log::trace!("drawing {num_draw_calls} renderlets using direct");
                 self.draw_direct(render_pass);
             }
+        } else {
+            log::warn!("zero draw calls");
         }
     }
 }

--- a/crates/renderling/src/lib.rs
+++ b/crates/renderling/src/lib.rs
@@ -19,7 +19,7 @@
 //! use renderling::prelude::*;
 //!
 //! // create a headless context with dimensions 100, 100.
-//! let ctx = Context::headless(100, 100);
+//! let ctx = futures_lite::future::block_on(Context::headless(100, 100));
 //! ```
 //!
 //! [`Context::headless`] creates a `Context` that renders to a texture.
@@ -30,7 +30,7 @@
 //!
 //! ```
 //! # use renderling::prelude::*;
-//! # let ctx = Context::headless(100, 100);
+//! # let ctx = futures_lite::future::block_on(Context::headless(100, 100));
 //! let stage: Stage = ctx
 //!     .new_stage()
 //!     .with_background_color([1.0, 1.0, 1.0, 1.0])
@@ -61,7 +61,7 @@
 //!
 //! ```
 //! # use renderling::prelude::*;
-//! # let ctx = Context::headless(100, 100);
+//! # let ctx = futures_lite::future::block_on(Context::headless(100, 100));
 //! # let stage: Stage = ctx.new_stage();
 //!
 //! let camera = stage.new_camera(Camera::default_ortho2d(100.0, 100.0));
@@ -98,7 +98,7 @@
 //!
 //! ```
 //! # use renderling::prelude::*;
-//! # let ctx = Context::headless(100, 100);
+//! # let ctx = futures_lite::future::block_on(Context::headless(100, 100));
 //! # let stage = ctx.new_stage();
 //! # let _camera = stage.new_camera(Camera::default_ortho2d(100.0, 100.0));
 //! # let _rez = stage.builder().with_vertices([
@@ -115,7 +115,7 @@
 //!
 //! let frame = ctx.get_next_frame().unwrap();
 //! stage.render(&frame.view());
-//! let img = frame.read_image().unwrap();
+//! let img = futures_lite::future::block_on(frame.read_image()).unwrap();
 //! frame.present();
 //! ```
 //!
@@ -237,6 +237,28 @@ mod test {
         workspace_dir().join("test_output")
     }
 
+    /// Marker trait to block on futures in synchronous code.
+    ///
+    /// This is a simple convenience.
+    /// Many of the tests in this crate render something and then read a
+    /// texture in order to perform a diff on the result using a known image.
+    /// Since reading from the GPU is async, this trait helps cut down
+    /// boilerplate.
+    pub trait BlockOnFuture {
+        type Output;
+
+        /// Block on the future using [`futures_util::future::block_on`].
+        fn block(self) -> Self::Output;
+    }
+
+    impl<T: std::future::Future> BlockOnFuture for T {
+        type Output = <Self as std::future::Future>::Output;
+
+        fn block(self) -> Self::Output {
+            futures_lite::future::block_on(self)
+        }
+    }
+
     pub fn make_two_directional_light_setup(stage: &Stage) -> (AnalyticalLight, AnalyticalLight) {
         let sunlight_a = stage.new_analytical_light(DirectionalLightDescriptor {
             direction: Vec3::new(-0.8, -1.0, 0.5).normalize(),
@@ -333,7 +355,7 @@ mod test {
     #[test]
     // This tests our ability to draw a CMYK triangle in the top left corner.
     fn cmy_triangle_sanity() {
-        let ctx = Context::headless(100, 100);
+        let ctx = Context::headless(100, 100).block();
         let stage = ctx.new_stage().with_background_color(Vec4::splat(1.0));
         let _camera = stage.new_camera(Camera::default_ortho2d(100.0, 100.0));
         let _rez = stage.builder().with_vertices(right_tri_vertices()).build();
@@ -343,7 +365,7 @@ mod test {
         frame.present();
 
         let depth_texture = stage.get_depth_texture();
-        let depth_img = depth_texture.read_image().unwrap().unwrap();
+        let depth_img = depth_texture.read_image().block().unwrap().unwrap();
         img_diff::assert_img_eq("cmy_triangle/depth.png", depth_img);
 
         let hdr_img = stage
@@ -351,10 +373,16 @@ mod test {
             .read()
             .unwrap()
             .read_hdr_image(&ctx)
+            .block()
             .unwrap();
         img_diff::assert_img_eq("cmy_triangle/hdr.png", hdr_img);
 
-        let bloom_mix = stage.bloom.get_mix_texture().read_hdr_image(&ctx).unwrap();
+        let bloom_mix = stage
+            .bloom
+            .get_mix_texture()
+            .read_hdr_image(&ctx)
+            .block()
+            .unwrap();
         img_diff::assert_img_eq("cmy_triangle/bloom_mix.png", bloom_mix);
     }
 
@@ -364,7 +392,7 @@ mod test {
     fn cmy_triangle_backface() {
         use img_diff::DiffCfg;
 
-        let ctx = Context::headless(100, 100);
+        let ctx = Context::headless(100, 100).block();
         let stage = ctx.new_stage().with_background_color(Vec4::splat(1.0));
         let _camera = stage.new_camera(Camera::default_ortho2d(100.0, 100.0));
         let _rez = stage
@@ -378,7 +406,7 @@ mod test {
 
         let frame = ctx.get_next_frame().unwrap();
         stage.render(&frame.view());
-        let img = frame.read_linear_image().unwrap();
+        let img = frame.read_linear_image().block().unwrap();
         img_diff::assert_img_eq_cfg(
             "cmy_triangle/hdr.png",
             img,
@@ -394,7 +422,7 @@ mod test {
     // has already been sent to the GPU.
     // We do this by writing over the previous transform in the stage.
     fn cmy_triangle_update_transform() {
-        let ctx = Context::headless(100, 100);
+        let ctx = Context::headless(100, 100).block();
         let stage = ctx.new_stage().with_background_color(Vec4::splat(1.0));
         let _camera = stage.new_camera(Camera::default_ortho2d(100.0, 100.0));
         let (_vertices, transform, _renderlet) = stage
@@ -413,7 +441,7 @@ mod test {
         });
 
         stage.render(&frame.view());
-        let img = frame.read_linear_image().unwrap();
+        let img = frame.read_linear_image().block().unwrap();
         img_diff::assert_img_eq("cmy_triangle/update_transform.png", img);
     }
 
@@ -459,7 +487,7 @@ mod test {
     #[test]
     // Tests our ability to draw a CMYK cube.
     fn cmy_cube_sanity() {
-        let ctx = Context::headless(100, 100);
+        let ctx = Context::headless(100, 100).block();
         let stage = ctx.new_stage().with_background_color(Vec4::splat(1.0));
         let camera_position = Vec3::new(0.0, 12.0, 20.0);
         let _camera = stage.new_camera(Camera::new(
@@ -478,14 +506,14 @@ mod test {
 
         let frame = ctx.get_next_frame().unwrap();
         stage.render(&frame.view());
-        let img = frame.read_image().unwrap();
+        let img = frame.read_image().block().unwrap();
         img_diff::assert_img_eq("cmy_cube/sanity.png", img);
     }
 
     #[test]
     // Tests our ability to draw a CMYK cube using indexed geometry.
     fn cmy_cube_indices() {
-        let ctx = Context::headless(100, 100);
+        let ctx = Context::headless(100, 100).block();
         let stage = ctx.new_stage().with_background_color(Vec4::splat(1.0));
         let camera_position = Vec3::new(0.0, 12.0, 20.0);
         let _camera = stage.new_camera(Camera::new(
@@ -505,7 +533,7 @@ mod test {
 
         let frame = ctx.get_next_frame().unwrap();
         stage.render(&frame.view());
-        let img = frame.read_image().unwrap();
+        let img = frame.read_image().block().unwrap();
         img_diff::assert_img_eq_cfg(
             "cmy_cube/sanity.png",
             img,
@@ -520,7 +548,7 @@ mod test {
     // Test our ability to create two cubes and toggle the visibility of one of
     // them.
     fn cmy_cube_visible() {
-        let ctx = Context::headless(100, 100);
+        let ctx = Context::headless(100, 100).block();
         let stage = ctx.new_stage().with_background_color(Vec4::splat(1.0));
         let (projection, view) = camera::default_perspective(100.0, 100.0);
         let _camera = stage.new_camera(Camera::new(projection, view));
@@ -547,7 +575,7 @@ mod test {
         // we should see two colored cubes
         let frame = ctx.get_next_frame().unwrap();
         stage.render(&frame.view());
-        let img = frame.read_image().unwrap();
+        let img = frame.read_image().block().unwrap();
         img_diff::assert_img_eq("cmy_cube/visible_before.png", img.clone());
         let img_before = img;
         frame.present();
@@ -558,7 +586,7 @@ mod test {
         // we should see only one colored cube
         let frame = ctx.get_next_frame().unwrap();
         stage.render(&frame.view());
-        let img = frame.read_image().unwrap();
+        let img = frame.read_image().block().unwrap();
         img_diff::assert_img_eq("cmy_cube/visible_after.png", img);
         frame.present();
 
@@ -568,7 +596,7 @@ mod test {
         // we should see two colored cubes again
         let frame = ctx.get_next_frame().unwrap();
         stage.render(&frame.view());
-        let img = frame.read_image().unwrap();
+        let img = frame.read_image().block().unwrap();
         img_diff::assert_eq("cmy_cube/visible_before_again.png", img_before, img);
     }
 
@@ -576,7 +604,7 @@ mod test {
     // Tests the ability to specify indexed vertices, as well as the ability to
     // update a field within a struct stored on the slab by using a `Hybrid`.
     fn cmy_cube_remesh() {
-        let ctx = Context::headless(100, 100);
+        let ctx = Context::headless(100, 100).block();
         let stage = ctx
             .new_stage()
             .with_lighting(false)
@@ -595,7 +623,7 @@ mod test {
         // we should see a cube (in sRGB color space)
         let frame = ctx.get_next_frame().unwrap();
         stage.render(&frame.view());
-        let img = frame.read_image().unwrap();
+        let img = frame.read_image().block().unwrap();
         img_diff::assert_img_eq("cmy_cube/remesh_before.png", img);
         frame.present();
 
@@ -609,7 +637,7 @@ mod test {
         // we should see a pyramid (in sRGB color space)
         let frame = ctx.get_next_frame().unwrap();
         stage.render(&frame.view());
-        let img = frame.read_image().unwrap();
+        let img = frame.read_image().block().unwrap();
         img_diff::assert_img_eq("cmy_cube/remesh_after.png", img);
     }
 
@@ -663,7 +691,7 @@ mod test {
     // Tests that updating the material actually updates the rendering of an unlit
     // mesh
     fn unlit_textured_cube_material() {
-        let ctx = Context::headless(100, 100);
+        let ctx = Context::headless(100, 100).block();
         let stage = ctx.new_stage().with_background_color(Vec4::splat(0.0));
         let (projection, view) = camera::default_perspective(100.0, 100.0);
         let _camera = stage.new_camera(Camera::new(projection, view));
@@ -690,7 +718,7 @@ mod test {
         // we should see a cube with a stoney texture
         let frame = ctx.get_next_frame().unwrap();
         stage.render(&frame.view());
-        let img = frame.read_image().unwrap();
+        let img = frame.read_image().block().unwrap();
         img_diff::assert_img_eq("unlit_textured_cube_material_before.png", img);
         frame.present();
 
@@ -700,7 +728,7 @@ mod test {
         // we should see a cube with a dirty texture
         let frame = ctx.get_next_frame().unwrap();
         stage.render(&frame.view());
-        let img = frame.read_image().unwrap();
+        let img = frame.read_image().block().unwrap();
         img_diff::assert_img_eq("unlit_textured_cube_material_after.png", img);
 
         // let size = stage.atlas.get_size();
@@ -717,7 +745,7 @@ mod test {
     // Ensures that we can render multiple nodes with mesh primitives
     // that share the same geometry, but have different materials.
     fn multi_node_scene() {
-        let ctx = Context::headless(100, 100);
+        let ctx = Context::headless(100, 100).block();
         let stage = ctx
             .new_stage()
             .with_background_color(Vec3::splat(0.0).extend(1.0));
@@ -773,7 +801,7 @@ mod test {
 
         let frame = ctx.get_next_frame().unwrap();
         stage.render(&frame.view());
-        let img = frame.read_image().unwrap();
+        let img = frame.read_image().block().unwrap();
         img_diff::assert_img_eq("stage/shared_node_with_different_materials.png", img);
     }
 
@@ -782,7 +810,7 @@ mod test {
     fn scene_cube_directional() {
         use crate::light::{DirectionalLightDescriptor, Light, LightStyle};
 
-        let ctx = Context::headless(100, 100);
+        let ctx = Context::headless(100, 100).block();
         let stage = ctx
             .new_stage()
             .with_bloom(false)
@@ -842,9 +870,9 @@ mod test {
 
         let frame = ctx.get_next_frame().unwrap();
         stage.render(&frame.view());
-        let img = frame.read_image().unwrap();
+        let img = frame.read_image().block().unwrap();
         let depth_texture = stage.get_depth_texture();
-        let depth_img = depth_texture.read_image().unwrap().unwrap();
+        let depth_img = depth_texture.read_image().block().unwrap().unwrap();
         img_diff::assert_img_eq("stage/cube_directional_depth.png", depth_img);
         img_diff::assert_img_eq("stage/cube_directional.png", img);
     }
@@ -890,7 +918,7 @@ mod test {
     // shows how to "nest" children to make them appear transformed by their
     // parent's transform
     fn scene_parent_sanity() {
-        let ctx = Context::headless(100, 100);
+        let ctx = Context::headless(100, 100).block();
         let stage = ctx.new_stage().with_background_color(Vec4::splat(0.0));
         let (projection, view) = camera::default_ortho2d(100.0, 100.0);
         let _camera = stage.new_camera(Camera::new(projection, view));
@@ -966,7 +994,7 @@ mod test {
 
         let frame = ctx.get_next_frame().unwrap();
         stage.render(&frame.view());
-        let img = frame.read_image().unwrap();
+        let img = frame.read_image().block().unwrap();
         img_diff::assert_img_eq("scene_parent_sanity.png", img);
     }
 
@@ -983,7 +1011,7 @@ mod test {
     #[test]
     fn can_resize_context_and_stage() {
         let size = UVec2::new(100, 100);
-        let mut ctx = Context::headless(size.x, size.y);
+        let mut ctx = Context::headless(size.x, size.y).block();
         let stage = ctx.new_stage();
 
         // create the CMY cube
@@ -1004,7 +1032,7 @@ mod test {
 
         let frame = ctx.get_next_frame().unwrap();
         stage.render(&frame.view());
-        let img = frame.read_image().unwrap();
+        let img = frame.read_image().block().unwrap();
         assert_eq!(size, UVec2::new(img.width(), img.height()));
         img_diff::assert_img_eq("stage/resize_100.png", img);
         frame.present();
@@ -1015,7 +1043,7 @@ mod test {
 
         let frame = ctx.get_next_frame().unwrap();
         stage.render(&frame.view());
-        let img = frame.read_image().unwrap();
+        let img = frame.read_image().block().unwrap();
         assert_eq!(new_size, UVec2::new(img.width(), img.height()));
         img_diff::assert_img_eq("stage/resize_200.png", img);
         frame.present();
@@ -1024,7 +1052,9 @@ mod test {
     #[test]
     fn can_direct_draw_cube() {
         let size = UVec2::new(100, 100);
-        let ctx = Context::headless(size.x, size.y).with_use_direct_draw(true);
+        let ctx = Context::headless(size.x, size.y)
+            .block()
+            .with_use_direct_draw(true);
         let stage = ctx.new_stage();
 
         // create the CMY cube
@@ -1045,7 +1075,7 @@ mod test {
 
         let frame = ctx.get_next_frame().unwrap();
         stage.render(&frame.view());
-        let img = frame.read_image().unwrap();
+        let img = frame.read_image().block().unwrap();
         assert_eq!(size, UVec2::new(img.width(), img.height()));
         img_diff::assert_img_eq("stage/resize_100.png", img);
         frame.present();

--- a/crates/renderling/src/lib.rs
+++ b/crates/renderling/src/lib.rs
@@ -222,7 +222,7 @@ mod test {
     use pretty_assertions::assert_eq;
     use stage::Stage;
 
-    #[ctor::ctor]
+    #[cfg_attr(not(target_arch = "wasm32"), ctor::ctor)]
     fn init_logging() {
         let _ = env_logger::builder().is_test(true).try_init();
         log::info!("logging is on");

--- a/crates/renderling/src/light/cpu/test.rs
+++ b/crates/renderling/src/light/cpu/test.rs
@@ -13,7 +13,7 @@ use crate::{
     math::GpuRng,
     pbr::Material,
     prelude::Transform,
-    stage::{Renderlet, RenderletPbrVertexInfo, Stage, Vertex},
+    stage::{Renderlet, RenderletPbrVertexInfo, Stage, Vertex}, test::BlockOnFuture,
 };
 
 use super::*;
@@ -84,7 +84,7 @@ fn spot_one_calc() {
 fn spot_one_frame() {
     let m = 32.0;
     let (w, h) = (16.0f32 * m, 9.0 * m);
-    let ctx = crate::Context::headless(w as u32, h as u32);
+    let ctx = crate::Context::headless(w as u32, h as u32).block();
     let stage = ctx.new_stage().with_msaa_sample_count(4);
     let doc = stage
         .load_gltf_document_from_path(
@@ -101,7 +101,7 @@ fn spot_one_frame() {
 
     let frame = ctx.get_next_frame().unwrap();
     stage.render(&frame.view());
-    let img = frame.read_image().unwrap();
+    let img = frame.read_image().block().unwrap();
     img_diff::assert_img_eq("light/spot_lights/one.png", img);
     frame.present();
 }
@@ -114,7 +114,7 @@ fn spot_one_frame() {
 fn spot_lights() {
     let w = 800.0;
     let h = 800.0;
-    let ctx = crate::Context::headless(w as u32, h as u32);
+    let ctx = crate::Context::headless(w as u32, h as u32).block();
     let stage = ctx
         .new_stage()
         .with_lighting(true)
@@ -141,7 +141,7 @@ fn spot_lights() {
 
     let frame = ctx.get_next_frame().unwrap();
     stage.render(&frame.view());
-    let img = frame.read_image().unwrap();
+    let img = frame.read_image().block().unwrap();
     img_diff::assert_img_eq("light/spot_lights/frame.png", img);
     frame.present();
 }
@@ -151,7 +151,7 @@ fn light_tiling_light_bounds() {
     let magnification = 8;
     let w = 16.0 * 2.0f32.powi(magnification);
     let h = 9.0 * 2.0f32.powi(magnification);
-    let ctx = crate::Context::headless(w as u32, h as u32);
+    let ctx = crate::Context::headless(w as u32, h as u32).block();
     let stage = ctx.new_stage().with_msaa_sample_count(4);
     let doc = stage
         .load_gltf_document_from_path(
@@ -219,7 +219,7 @@ fn light_tiling_light_bounds() {
 
     let frame = ctx.get_next_frame().unwrap();
     stage.render(&frame.view());
-    let img = frame.read_image().unwrap();
+    let img = frame.read_image().block().unwrap();
     img_diff::save("light/tiling/bounds.png", img);
     frame.present();
 }
@@ -339,7 +339,7 @@ fn clear_tiles_sanity() {
     let _ = env_logger::builder().is_test(true).try_init();
     let s = 256;
     let depth_texture_size = UVec2::splat(s);
-    let ctx = crate::Context::headless(s, s);
+    let ctx = crate::Context::headless(s, s).block();
     let stage = ctx.new_stage();
     let lighting: &Lighting = stage.as_ref();
     let tiling_config = LightTilingConfig::default();
@@ -410,7 +410,7 @@ fn min_max_depth_sanity() {
     let _ = env_logger::builder().is_test(true).try_init();
     let s = 256;
     let depth_texture_size = UVec2::splat(s);
-    let ctx = crate::Context::headless(s, s);
+    let ctx = crate::Context::headless(s, s).block();
     let stage = ctx.new_stage();
     let _doc = stage
         .load_gltf_document_from_path(
@@ -462,7 +462,7 @@ fn light_bins_sanity() {
     let _ = env_logger::builder().is_test(true).try_init();
     let s = 256;
     let depth_texture_size = UVec2::splat(s);
-    let ctx = crate::Context::headless(s, s);
+    let ctx = crate::Context::headless(s, s).block();
     let stage = ctx.new_stage();
     let doc = stage
         .load_gltf_document_from_path(
@@ -532,7 +532,7 @@ fn light_bins_sanity() {
 // Ensures point lights are being binned properly.
 #[test]
 fn light_bins_point() {
-    let ctx = crate::Context::headless(256, 256);
+    let ctx = crate::Context::headless(256, 256).block();
     let stage = ctx
         .new_stage()
         .with_msaa_sample_count(1)
@@ -605,7 +605,7 @@ fn tiling_e2e_sanity_with(
         minimum_illuminance: {minimum_illuminance}"
     );
     let size = size();
-    let ctx = crate::Context::headless(size.x, size.y);
+    let ctx = crate::Context::headless(size.x, size.y).block();
     let stage = ctx
         .new_stage()
         .with_bloom(true)
@@ -783,7 +783,7 @@ fn snapshot(ctx: &crate::Context, stage: &Stage, path: &str, save: bool) {
     stage.render(&frame.view());
     let   elapsed = start.elapsed();
     log::info!("shapshot: {}s '{path}'", elapsed.as_secs_f32());
-    let img = frame.read_image().unwrap();
+    let img = frame.read_image().block().unwrap();
     if save {
         img_diff::save(path, img);
     } else {
@@ -943,7 +943,7 @@ mod stats {
 /// In other words, light w/ nested transform is the same as light with
 /// that same transform pre-applied.
 fn pedestal() {
-    let ctx = crate::Context::headless(256, 256);
+    let ctx = crate::Context::headless(256, 256).block();
     let stage = ctx
         .new_stage()
         .with_lighting(false)

--- a/crates/renderling/src/light/shadow_map.rs
+++ b/crates/renderling/src/light/shadow_map.rs
@@ -368,7 +368,7 @@ impl ShadowMap {
 #[cfg(test)]
 #[allow(clippy::unused_enumerate_index)]
 mod test {
-    use crate::camera::Camera;
+    use crate::{camera::Camera, test::BlockOnFuture};
 
     use super::super::*;
 
@@ -376,7 +376,7 @@ mod test {
     fn shadow_mapping_just_cuboid() {
         let w = 800.0;
         let h = 800.0;
-        let ctx = crate::Context::headless(w as u32, h as u32);
+        let ctx = crate::Context::headless(w as u32, h as u32).block();
         let stage = ctx
             .new_stage()
             .with_lighting(true)
@@ -403,7 +403,7 @@ mod test {
 
         let frame = ctx.get_next_frame().unwrap();
         stage.render(&frame.view());
-        let img = frame.read_image().unwrap();
+        let img = frame.read_image().block().unwrap();
         frame.present();
 
         // Rendering the scene without shadows as a sanity check
@@ -421,7 +421,7 @@ mod test {
 
         let frame = ctx.get_next_frame().unwrap();
         stage.render(&frame.view());
-        let img = frame.read_image().unwrap();
+        let img = frame.read_image().block().unwrap();
         img_diff::assert_img_eq("shadows/shadow_mapping_just_cuboid/scene_after.png", img);
         frame.present();
     }
@@ -430,7 +430,7 @@ mod test {
     fn shadow_mapping_just_cuboid_red_and_blue() {
         let w = 800.0;
         let h = 800.0;
-        let ctx = crate::Context::headless(w as u32, h as u32);
+        let ctx = crate::Context::headless(w as u32, h as u32).block();
         let stage = ctx
             .new_stage()
             .with_lighting(true)
@@ -471,7 +471,7 @@ mod test {
         let frame = ctx.get_next_frame().unwrap();
 
         stage.render(&frame.view());
-        let img = frame.read_image().unwrap();
+        let img = frame.read_image().block().unwrap();
         img_diff::assert_img_eq(
             "shadows/shadow_mapping_just_cuboid/red_and_blue/frame.png",
             img,
@@ -484,6 +484,7 @@ mod test {
         let w = 800.0;
         let h = 800.0;
         let ctx = crate::Context::headless(w as u32, h as u32)
+            .block()
             .with_shadow_mapping_atlas_texture_size([1024, 1024, 2]);
         let stage = ctx.new_stage().with_lighting(true);
 
@@ -502,7 +503,7 @@ mod test {
 
         let frame = ctx.get_next_frame().unwrap();
         stage.render(&frame.view());
-        let img = frame.read_image().unwrap();
+        let img = frame.read_image().block().unwrap();
         frame.present();
 
         // Rendering the scene without shadows as a sanity check
@@ -553,7 +554,7 @@ mod test {
         let frame = ctx.get_next_frame().unwrap();
         stage.render(&frame.view());
 
-        let img = frame.read_image().unwrap();
+        let img = frame.read_image().block().unwrap();
         frame.present();
         img_diff::assert_img_eq_cfg(
             "shadows/shadow_mapping_sanity/stage_render.png",
@@ -569,7 +570,7 @@ mod test {
     fn shadow_mapping_spot_lights() {
         let w = 800.0;
         let h = 800.0;
-        let ctx = crate::Context::headless(w as u32, h as u32);
+        let ctx = crate::Context::headless(w as u32, h as u32).block();
         let stage = ctx
             .new_stage()
             .with_lighting(true)
@@ -603,7 +604,7 @@ mod test {
                 camera.as_ref().set(Camera::new(p, v));
                 let frame = ctx.get_next_frame().unwrap();
                 stage.render(&frame.view());
-                let _img = frame.read_image().unwrap();
+                let _img = frame.read_image().block().unwrap();
                 // img_diff::assert_img_eq(
                 //     &format!("shadows/shadow_mapping_spots/light_pov_{i}.png"),
                 //     img,
@@ -625,7 +626,7 @@ mod test {
 
         let frame = ctx.get_next_frame().unwrap();
         stage.render(&frame.view());
-        let img = frame.read_image().unwrap();
+        let img = frame.read_image().block().unwrap();
         img_diff::assert_img_eq("shadows/shadow_mapping_spots/frame.png", img);
         frame.present();
     }
@@ -634,7 +635,7 @@ mod test {
     fn shadow_mapping_point_lights() {
         let w = 800.0;
         let h = 800.0;
-        let ctx = crate::Context::headless(w as u32, h as u32);
+        let ctx = crate::Context::headless(w as u32, h as u32).block();
         let stage = ctx
             .new_stage()
             .with_lighting(true)
@@ -670,7 +671,7 @@ mod test {
                     camera.as_ref().set(Camera::new(p, v));
                     let frame = ctx.get_next_frame().unwrap();
                     stage.render(&frame.view());
-                    let _img = frame.read_image().unwrap();
+                    let _img = frame.read_image().block().unwrap();
                     // img_diff::assert_img_eq(
                     //     &format!("shadows/shadow_mapping_points/light_{i}_pov_{j}.png"),
                     //     img,
@@ -693,7 +694,7 @@ mod test {
 
         let frame = ctx.get_next_frame().unwrap();
         stage.render(&frame.view());
-        let img = frame.read_image().unwrap();
+        let img = frame.read_image().block().unwrap();
         img_diff::assert_img_eq("shadows/shadow_mapping_points/frame.png", img);
         frame.present();
     }

--- a/crates/renderling/src/math.rs
+++ b/crates/renderling/src/math.rs
@@ -12,7 +12,7 @@ use spirv_std::{
     Image, Sampler,
 };
 
-pub use glam::*;
+use glam::*;
 pub use spirv_std::num_traits::{clamp, Float, Zero};
 
 pub trait Fetch<Coords> {

--- a/crates/renderling/src/pbr.rs
+++ b/crates/renderling/src/pbr.rs
@@ -717,8 +717,8 @@ mod test {
     use crate::{
         atlas::AtlasImage,
         camera::Camera,
-        math::{Vec3, Vec4},
         pbr::Material,
+        prelude::glam::{Vec3, Vec4},
         stage::Vertex,
         transform::Transform,
     };

--- a/crates/renderling/src/pbr.rs
+++ b/crates/renderling/src/pbr.rs
@@ -720,6 +720,7 @@ mod test {
         pbr::Material,
         prelude::glam::{Vec3, Vec4},
         stage::Vertex,
+        test::BlockOnFuture,
         transform::Transform,
     };
 
@@ -730,7 +731,7 @@ mod test {
     // see https://learnopengl.com/PBR/Lighting
     fn pbr_metallic_roughness_spheres() {
         let ss = 600;
-        let ctx = crate::Context::headless(ss, ss);
+        let ctx = crate::Context::headless(ss, ss).block();
         let stage = ctx.new_stage();
 
         let radius = 0.5;
@@ -807,7 +808,7 @@ mod test {
 
         let frame = ctx.get_next_frame().unwrap();
         stage.render(&frame.view());
-        let img = frame.read_image().unwrap();
+        let img = frame.read_image().block().unwrap();
         img_diff::assert_img_eq("pbr/metallic_roughness_spheres.png", img);
     }
 }

--- a/crates/renderling/src/sdf.rs
+++ b/crates/renderling/src/sdf.rs
@@ -2,17 +2,23 @@
 //!
 //! For more info, see these great articles:
 //! - <https://iquilezles.org/articles/distfunctions2d/>
-
 use crabslab::SlabItem;
 use glam::Vec2;
+// use spirv_std::spirv;
+
+// #[spirv(vertex)]
+// pub fn vertex_sdf_circle(
+//     #[spirv(instance_index)] circle_id: Id<CircleDescriptor>,
+//     #[spirv(vertex_index)] vertex_index: u32,
+// )
 
 #[derive(Clone, Copy, SlabItem)]
-pub struct Circle {
+pub struct CircleDescriptor {
     pub center: Vec2,
     pub radius: f32,
 }
 
-impl Circle {
+impl CircleDescriptor {
     pub fn distance(&self, point: Vec2) -> f32 {
         let p = point - self.center;
         p.length() - self.radius
@@ -46,7 +52,7 @@ mod test {
     fn sdf_circle_sanity() {
         let mut img = image::ImageBuffer::<image::Luma<f32>, Vec<f32>>::new(32, 32);
 
-        let circle = Circle {
+        let circle = CircleDescriptor {
             center: Vec2::new(12.0, 12.0),
             radius: 4.0,
         };

--- a/crates/renderling/src/skybox/cpu.rs
+++ b/crates/renderling/src/skybox/cpu.rs
@@ -650,11 +650,11 @@ mod test {
     use glam::Vec3;
 
     use super::*;
-    use crate::Context;
+    use crate::{test::BlockOnFuture, Context};
 
     #[test]
     fn hdr_skybox_scene() {
-        let ctx = Context::headless(600, 400);
+        let ctx = Context::headless(600, 400).block();
 
         let proj = crate::camera::perspective(600.0, 400.0);
         let view = crate::camera::look_at(Vec3::new(0.0, 0.0, 2.0), Vec3::ZERO, Vec3::Y);
@@ -687,7 +687,7 @@ mod test {
                 0,
                 Some(wgpu::Origin3d { x: 0, y: 0, z: i }),
             );
-            let pixels = copied_buffer.pixels(ctx.get_device()).unwrap();
+            let pixels = copied_buffer.pixels(ctx.get_device()).block().unwrap();
             let pixels = bytemuck::cast_slice::<u8, u16>(pixels.as_slice())
                 .iter()
                 .map(|p| half::f16::from_bits(*p).to_f32())
@@ -710,7 +710,7 @@ mod test {
                     mip_level,
                     Some(wgpu::Origin3d { x: 0, y: 0, z: i }),
                 );
-                let pixels = copied_buffer.pixels(ctx.get_device()).unwrap();
+                let pixels = copied_buffer.pixels(ctx.get_device()).block().unwrap();
                 let pixels = bytemuck::cast_slice::<u8, u16>(pixels.as_slice())
                     .iter()
                     .map(|p| half::f16::from_bits(*p).to_f32())
@@ -731,18 +731,18 @@ mod test {
 
         let frame = ctx.get_next_frame().unwrap();
         stage.render(&frame.view());
-        let img = frame.read_linear_image().unwrap();
+        let img = frame.read_linear_image().block().unwrap();
         img_diff::assert_img_eq("skybox/hdr.png", img);
     }
 
     #[test]
     fn precomputed_brdf() {
         assert_eq!(2, std::mem::size_of::<u16>());
-        let r = Context::headless(32, 32);
+        let r = Context::headless(32, 32).block();
         let brdf_lut = Skybox::create_precomputed_brdf_texture(&r);
         assert_eq!(wgpu::TextureFormat::Rg16Float, brdf_lut.texture.format());
         let copied_buffer = Texture::read(&r, &brdf_lut.texture, 512, 512, 2, 2);
-        let pixels = copied_buffer.pixels(r.get_device()).unwrap();
+        let pixels = copied_buffer.pixels(r.get_device()).block().unwrap();
         let pixels: Vec<f32> = bytemuck::cast_slice::<u8, u16>(pixels.as_slice())
             .iter()
             .copied()

--- a/crates/renderling/src/stage/cpu.rs
+++ b/crates/renderling/src/stage/cpu.rs
@@ -2,6 +2,8 @@
 //!
 //! The `Stage` object contains a slab buffer and a render pipeline.
 //! It is used to stage [`Renderlet`]s for rendering.
+#[cfg(test)]
+use core::ops::Deref;
 use core::sync::atomic::{AtomicU32, AtomicUsize, Ordering};
 use craballoc::prelude::*;
 use crabslab::Id;
@@ -768,6 +770,11 @@ impl Stage {
         &self.runtime().queue
     }
 
+    #[cfg(feature = "test-helpers")]
+    pub fn hdr_texture(&self) -> impl Deref<Target = crate::texture::Texture> + '_ {
+        self.hdr_texture.read().unwrap()
+    }
+
     pub fn builder(&self) -> RenderletBuilder<'_, ()> {
         RenderletBuilder::new(self)
     }
@@ -1427,6 +1434,11 @@ impl Stage {
         path: impl AsRef<std::path::Path>,
     ) -> Result<Skybox, AtlasImageError> {
         let hdr = AtlasImage::from_hdr_path(path)?;
+        Ok(Skybox::new(self.runtime(), hdr))
+    }
+
+    pub fn new_skybox_from_bytes(&self, bytes: &[u8]) -> Result<Skybox, AtlasImageError> {
+        let hdr = AtlasImage::from_hdr_bytes(bytes)?;
         Ok(Skybox::new(self.runtime(), hdr))
     }
 

--- a/crates/renderling/src/stage/gltf_support.rs
+++ b/crates/renderling/src/stage/gltf_support.rs
@@ -1216,7 +1216,10 @@ impl Stage {
 
 #[cfg(test)]
 mod test {
-    use crate::{camera::Camera, pbr::Material, stage::Vertex, transform::Transform, Context};
+    use crate::{
+        camera::Camera, pbr::Material, stage::Vertex, test::BlockOnFuture, transform::Transform,
+        Context,
+    };
     use glam::{Vec3, Vec4};
 
     #[test]
@@ -1241,7 +1244,7 @@ mod test {
     // * support primitives w/ positions and normal attributes
     // * support transforming nodes (T * R * S)
     fn stage_gltf_simple_meshes() {
-        let ctx = Context::headless(100, 50);
+        let ctx = Context::headless(100, 50).block();
         let projection = crate::camera::perspective(100.0, 50.0);
         let position = Vec3::new(1.0, 0.5, 1.5);
         let view = crate::camera::look_at(position, Vec3::new(1.0, 0.5, 0.0), Vec3::Y);
@@ -1257,14 +1260,14 @@ mod test {
 
         let frame = ctx.get_next_frame().unwrap();
         stage.render(&frame.view());
-        let img = frame.read_image().unwrap();
+        let img = frame.read_image().block().unwrap();
         img_diff::assert_img_eq("gltf/simple_meshes.png", img);
     }
 
     #[test]
     // Ensures we can read a minimal gltf file with a simple triangle mesh.
     fn minimal_mesh() {
-        let ctx = Context::headless(20, 20);
+        let ctx = Context::headless(20, 20).block();
         let stage = ctx
             .new_stage()
             .with_lighting(false)
@@ -1282,7 +1285,7 @@ mod test {
 
         let frame = ctx.get_next_frame().unwrap();
         stage.render(&frame.view());
-        let img = frame.read_image().unwrap();
+        let img = frame.read_image().block().unwrap();
         img_diff::assert_img_eq("gltf/minimal_mesh.png", img);
     }
 
@@ -1291,7 +1294,7 @@ mod test {
     //
     // This ensures we are decoding images correctly.
     fn gltf_images() {
-        let ctx = Context::headless(100, 100);
+        let ctx = Context::headless(100, 100).block();
         let stage = ctx
             .new_stage()
             .with_lighting(false)
@@ -1333,14 +1336,14 @@ mod test {
 
         let frame = ctx.get_next_frame().unwrap();
         stage.render(&frame.view());
-        let img = frame.read_linear_image().unwrap();
+        let img = frame.read_linear_image().block().unwrap();
         img_diff::assert_img_eq("gltf/images.png", img);
     }
 
     #[test]
     fn simple_texture() {
         let size = 100;
-        let ctx = Context::headless(size, size);
+        let ctx = Context::headless(size, size).block();
         let stage = ctx
             .new_stage()
             .with_background_color(Vec3::splat(0.0).extend(1.0))
@@ -1359,7 +1362,7 @@ mod test {
 
         let frame = ctx.get_next_frame().unwrap();
         stage.render(&frame.view());
-        let img = frame.read_image().unwrap();
+        let img = frame.read_image().block().unwrap();
         img_diff::assert_img_eq("gltf/simple_texture.png", img);
     }
 
@@ -1367,7 +1370,7 @@ mod test {
     // Demonstrates how to load and render a gltf file containing lighting and a
     // normal map.
     fn normal_mapping_brick_sphere() {
-        let ctx = Context::headless(1920, 1080);
+        let ctx = Context::headless(1920, 1080).block();
         let stage = ctx
             .new_stage()
             .with_lighting(true)
@@ -1379,13 +1382,13 @@ mod test {
 
         let frame = ctx.get_next_frame().unwrap();
         stage.render(&frame.view());
-        let img = frame.read_image().unwrap();
+        let img = frame.read_image().block().unwrap();
         img_diff::assert_img_eq("gltf/normal_mapping_brick_sphere.png", img);
     }
 
     #[test]
     fn rigged_fox() {
-        let ctx = Context::headless(256, 256);
+        let ctx = Context::headless(256, 256).block();
         let stage = ctx
             .new_stage()
             .with_lighting(false)
@@ -1413,14 +1416,14 @@ mod test {
         // render a frame without vertex skinning as a baseline
         let frame = ctx.get_next_frame().unwrap();
         stage.render(&frame.view());
-        let img = frame.read_image().unwrap();
+        let img = frame.read_image().block().unwrap();
         img_diff::assert_img_eq("gltf/skinning/rigged_fox_no_skinning.png", img);
 
         // render a frame with vertex skinning to ensure our rigging is correct
         stage.set_has_vertex_skinning(true);
         let frame = ctx.get_next_frame().unwrap();
         stage.render(&frame.view());
-        let img = frame.read_image().unwrap();
+        let img = frame.read_image().block().unwrap();
         img_diff::assert_img_eq_cfg(
             "gltf/skinning/rigged_fox_no_skinning.png",
             img,
@@ -1469,7 +1472,7 @@ mod test {
         // Test that the camera has the expected translation,
         // taking into account that the gltf files may have been
         // saved with Y up, or with Z up
-        let ctx = Context::headless(100, 100);
+        let ctx = Context::headless(100, 100).block();
         let stage = ctx.new_stage();
         let doc = stage
             .load_gltf_document_from_path(

--- a/crates/renderling/src/stage/gltf_support/anime.rs
+++ b/crates/renderling/src/stage/gltf_support/anime.rs
@@ -771,12 +771,12 @@ impl Animator {
 
 #[cfg(test)]
 mod test {
-    use crate::{camera::Camera, stage::Animator, Context};
+    use crate::{camera::Camera, stage::Animator, test::BlockOnFuture, Context};
     use glam::Vec3;
 
     #[test]
     fn gltf_simple_animation() {
-        let ctx = Context::headless(16, 16);
+        let ctx = Context::headless(16, 16).block();
         let stage = ctx
             .new_stage()
             .with_bloom(false)
@@ -798,7 +798,7 @@ mod test {
 
         let frame = ctx.get_next_frame().unwrap();
         stage.render(&frame.view());
-        let img = frame.read_image().unwrap();
+        let img = frame.read_image().block().unwrap();
         img_diff::save("animation/triangle.png", img);
         frame.present();
 
@@ -807,7 +807,7 @@ mod test {
             animator.progress(dt).unwrap();
             let frame = ctx.get_next_frame().unwrap();
             stage.render(&frame.view());
-            let img = frame.read_image().unwrap();
+            let img = frame.read_image().block().unwrap();
             img_diff::save(format!("animation/triangle{i}.png"), img);
             frame.present();
         }

--- a/crates/renderling/src/stage/gltf_support/anime.rs
+++ b/crates/renderling/src/stage/gltf_support/anime.rs
@@ -771,7 +771,8 @@ impl Animator {
 
 #[cfg(test)]
 mod test {
-    use crate::{camera::Camera, math::Vec3, stage::Animator, Context};
+    use crate::{camera::Camera, stage::Animator, Context};
+    use glam::Vec3;
 
     #[test]
     fn gltf_simple_animation() {

--- a/crates/renderling/src/ui.rs
+++ b/crates/renderling/src/ui.rs
@@ -25,3 +25,5 @@
 mod cpu;
 #[cfg(cpu)]
 pub use cpu::*;
+
+pub mod sdf;

--- a/crates/renderling/src/ui.rs
+++ b/crates/renderling/src/ui.rs
@@ -8,7 +8,7 @@
 //! use renderling::ui::prelude::*;
 //! use glam::Vec2;
 //!
-//! let ctx = Context::headless(100, 100);
+//! let ctx = futures_lite::future::block_on(Context::headless(100, 100));
 //! let mut ui = Ui::new(&ctx);
 //!
 //! let _path = ui

--- a/crates/renderling/src/ui/cpu.rs
+++ b/crates/renderling/src/ui/cpu.rs
@@ -6,13 +6,13 @@ use crate::{
     atlas::AtlasTexture,
     camera::Camera,
     geometry::Geometry,
-    math::{Quat, UVec2, Vec2, Vec3Swizzles, Vec4},
     stage::{NestedTransform, Renderlet, Stage},
     transform::Transform,
     Context,
 };
 use craballoc::prelude::{Hybrid, SourceId};
 use crabslab::Id;
+use glam::{Quat, UVec2, Vec2, Vec3Swizzles, Vec4};
 use glyph_brush::ab_glyph;
 use rustc_hash::FxHashMap;
 use snafu::{prelude::*, ResultExt};
@@ -105,7 +105,7 @@ impl UiTransform {
         self.transform
             .get()
             .rotation
-            .to_euler(crate::math::EulerRot::XYZ)
+            .to_euler(glam::EulerRot::XYZ)
             .2
     }
 
@@ -152,7 +152,8 @@ impl Ui {
             .with_background_color(Vec4::ONE)
             .with_lighting(false)
             .with_bloom(false)
-            .with_msaa_sample_count(4);
+            .with_msaa_sample_count(4)
+            .with_frustum_culling(false);
         let camera = stage.new_camera(Camera::default_ortho2d(x as f32, y as f32));
         Ui {
             camera,
@@ -342,12 +343,7 @@ impl Ui {
 
 #[cfg(test)]
 pub(crate) mod test {
-    use crate::{color::rgb_hex_color, math::Vec4};
-
-    #[ctor::ctor]
-    fn init_logging() {
-        let _ = env_logger::builder().is_test(true).try_init();
-    }
+    use crate::{color::rgb_hex_color, prelude::glam::Vec4};
 
     pub struct Colors<const N: usize>(std::iter::Cycle<std::array::IntoIter<Vec4, N>>);
 

--- a/crates/renderling/src/ui/cpu/path.rs
+++ b/crates/renderling/src/ui/cpu/path.rs
@@ -525,6 +525,7 @@ impl UiPathBuilder {
 mod test {
     use crate::{
         math::hex_to_vec4,
+        test::BlockOnFuture,
         ui::{
             test::{cute_beach_palette, Colors},
             Ui,
@@ -556,7 +557,7 @@ mod test {
 
     #[test]
     fn can_build_path_sanity() {
-        let ctx = Context::headless(100, 100);
+        let ctx = Context::headless(100, 100).block();
         let ui = Ui::new(&ctx).with_antialiasing(false);
         let builder = ui
             .new_path()
@@ -570,7 +571,7 @@ mod test {
 
             let frame = ctx.get_next_frame().unwrap();
             ui.render(&frame.view());
-            let img = frame.read_image().unwrap();
+            let img = frame.read_image().block().unwrap();
             img_diff::assert_img_eq("ui/path/sanity.png", img);
         }
 
@@ -582,7 +583,7 @@ mod test {
             let _resources = builder.fill_and_stroke();
             let frame = ctx.get_next_frame().unwrap();
             ui.render(&frame.view());
-            let img = frame.read_image().unwrap();
+            let img = frame.read_image().block().unwrap();
             img_diff::assert_img_eq_cfg(
                 "ui/path/sanity.png",
                 img,
@@ -596,7 +597,7 @@ mod test {
 
     #[test]
     fn can_draw_shapes() {
-        let ctx = Context::headless(256, 48);
+        let ctx = Context::headless(256, 48).block();
         let ui = Ui::new(&ctx).with_default_stroke_options(StrokeOptions {
             line_width: 4.0,
             ..Default::default()
@@ -672,14 +673,14 @@ mod test {
 
         let frame = ctx.get_next_frame().unwrap();
         ui.render(&frame.view());
-        let img = frame.read_image().unwrap();
+        let img = frame.read_image().block().unwrap();
         img_diff::assert_img_eq("ui/path/shapes.png", img);
     }
 
     #[test]
     fn can_fill_image() {
         let w = 150.0;
-        let ctx = Context::headless(w as u32, w as u32);
+        let ctx = Context::headless(w as u32, w as u32).block();
         let ui = Ui::new(&ctx);
         let image_id = futures_lite::future::block_on(ui.load_image("../../img/dirt.jpg")).unwrap();
         let center = Vec2::splat(w / 2.0);
@@ -706,7 +707,7 @@ mod test {
 
         let frame = ctx.get_next_frame().unwrap();
         ui.render(&frame.view());
-        let mut img = frame.read_srgb_image().unwrap();
+        let mut img = frame.read_srgb_image().block().unwrap();
         img.pixels_mut().for_each(|p| {
             crate::color::opto_xfer_u8(&mut p.0[0]);
             crate::color::opto_xfer_u8(&mut p.0[1]);

--- a/crates/renderling/src/ui/cpu/path.rs
+++ b/crates/renderling/src/ui/cpu/path.rs
@@ -2,12 +2,12 @@
 //!
 //! Path colors are sRGB.
 use crate::{
-    math::{Vec2, Vec3, Vec3Swizzles, Vec4},
     pbr::Material,
     stage::{Renderlet, Vertex},
 };
 use craballoc::prelude::{GpuArray, Hybrid};
 use crabslab::Id;
+use glam::{Vec2, Vec3, Vec3Swizzles, Vec4};
 use lyon::{
     path::traits::PathBuilder,
     tessellation::{
@@ -524,13 +524,14 @@ impl UiPathBuilder {
 #[cfg(test)]
 mod test {
     use crate::{
-        math::{hex_to_vec4, Vec2},
+        math::hex_to_vec4,
         ui::{
             test::{cute_beach_palette, Colors},
             Ui,
         },
         Context,
     };
+    use glam::Vec2;
 
     use super::*;
 

--- a/crates/renderling/src/ui/cpu/text.rs
+++ b/crates/renderling/src/ui/cpu/text.rs
@@ -9,6 +9,7 @@ use std::{
 
 use ab_glyph::Rect;
 use craballoc::prelude::{GpuArray, Hybrid};
+use glam::{Vec2, Vec4};
 use glyph_brush::*;
 
 pub use ab_glyph::FontArc;
@@ -16,7 +17,6 @@ pub use glyph_brush::{Section, Text};
 
 use crate::{
     atlas::AtlasTexture,
-    math::{Vec2, Vec4},
     pbr::Material,
     stage::{Renderlet, Vertex},
 };

--- a/crates/renderling/src/ui/cpu/text.rs
+++ b/crates/renderling/src/ui/cpu/text.rs
@@ -330,7 +330,7 @@ impl GlyphCache {
 
 #[cfg(test)]
 mod test {
-    use crate::{ui::Ui, Context};
+    use crate::{test::BlockOnFuture, ui::Ui, Context};
     use glyph_brush::Section;
 
     use super::*;
@@ -342,7 +342,7 @@ mod test {
             std::fs::read("../../fonts/Recursive Mn Lnr St Med Nerd Font Complete.ttf").unwrap();
         let font = FontArc::try_from_vec(bytes).unwrap();
 
-        let ctx = Context::headless(455, 145);
+        let ctx = Context::headless(455, 145).block();
         let ui = Ui::new(&ctx);
         let _font_id = ui.add_font(font);
         let _text = ui
@@ -374,7 +374,7 @@ mod test {
 
         let frame = ctx.get_next_frame().unwrap();
         ui.render(&frame.view());
-        let img = frame.read_image().unwrap();
+        let img = frame.read_image().block().unwrap();
         img_diff::assert_img_eq("ui/text/can_display.png", img);
     }
 
@@ -384,7 +384,7 @@ mod test {
     fn text_overlayed() {
         log::info!("{:#?}", std::env::current_dir());
 
-        let ctx = Context::headless(500, 253);
+        let ctx = Context::headless(500, 253).block();
         let ui = Ui::new(&ctx).with_antialiasing(false);
         let font_id = futures_lite::future::block_on(
             ui.load_font("../../fonts/Recursive Mn Lnr St Med Nerd Font Complete.ttf"),
@@ -432,15 +432,21 @@ mod test {
 
         let frame = ctx.get_next_frame().unwrap();
         ui.render(&frame.view());
-        let img = frame.read_image().unwrap();
+        let img = frame.read_image().block().unwrap();
         img_diff::assert_img_eq("ui/text/overlay.png", img);
-        let depth_img = ui.stage.get_depth_texture().read_image().unwrap().unwrap();
+        let depth_img = ui
+            .stage
+            .get_depth_texture()
+            .read_image()
+            .block()
+            .unwrap()
+            .unwrap();
         img_diff::assert_img_eq("ui/text/overlay_depth.png", depth_img);
     }
 
     #[test]
     fn recreate_text() {
-        let ctx = Context::headless(50, 50);
+        let ctx = Context::headless(50, 50).block();
         let ui = Ui::new(&ctx).with_antialiasing(true);
         let _font_id = futures_lite::future::block_on(
             ui.load_font("../../fonts/Recursive Mn Lnr St Med Nerd Font Complete.ttf"),
@@ -461,7 +467,7 @@ mod test {
 
         let frame = ctx.get_next_frame().unwrap();
         ui.render(&frame.view());
-        let img = frame.read_image().unwrap();
+        let img = frame.read_image().block().unwrap();
         frame.present();
         img_diff::assert_img_eq("ui/text/can_recreate_0.png", img);
 
@@ -481,7 +487,7 @@ mod test {
 
         let frame = ctx.get_next_frame().unwrap();
         ui.render(&frame.view());
-        let img = frame.read_image().unwrap();
+        let img = frame.read_image().block().unwrap();
         frame.present();
         img_diff::assert_img_eq("ui/text/can_recreate_1.png", img);
     }

--- a/crates/renderling/src/ui/sdf.rs
+++ b/crates/renderling/src/ui/sdf.rs
@@ -1,0 +1,23 @@
+//! 2d signed distance fields.
+use glam::Vec2;
+
+/// Returns the distance to the edge of a circle of radius `r` with center at `p`.
+fn distance_circle(p: Vec2, r: f32) -> f32 {
+    p.length() - r
+}
+
+pub struct Circle {
+    origin: Vec2,
+    radius: f32,
+}
+
+impl Circle {
+    pub fn distance(&self) -> f32 {
+        distance_circle(self.origin, self.radius)
+    }
+}
+
+// #[spirv_std::spirv(vertex)]
+// pub fn vertex_circle(
+
+// )

--- a/crates/renderling/tests/wasm.rs
+++ b/crates/renderling/tests/wasm.rs
@@ -92,7 +92,7 @@ async fn can_clear_background() {
         .with_background_color(Vec4::new(1.0, 0.0, 0.0, 1.0));
     let frame = ctx.get_next_frame().unwrap();
     stage.render(&frame.view());
-    let seen = frame.read_image().unwrap();
+    let seen = frame.read_image().await.unwrap();
     assert_img_eq("cmy_triangle/hdr.png", seen).await;
 }
 

--- a/crates/renderling/tests/wasm.rs
+++ b/crates/renderling/tests/wasm.rs
@@ -1,0 +1,122 @@
+//! WASM tests.
+#![allow(dead_code)]
+
+use glam::Vec4;
+use image::DynamicImage;
+use renderling::prelude::*;
+use wasm_bindgen_test::{wasm_bindgen_test, wasm_bindgen_test_configure};
+use web_sys::wasm_bindgen::UnwrapThrowExt;
+use wire_types::{Error, PixelType};
+
+wasm_bindgen_test_configure!(run_in_browser);
+
+#[wasm_bindgen_test]
+async fn can_create_headless_ctx() {
+    let _ctx = renderling::Context::try_new_headless(256, 256, None)
+        .await
+        .unwrap_throw();
+}
+
+#[wasm_bindgen_test]
+async fn stage_creation() {
+    let ctx = renderling::Context::try_new_headless(256, 256, None)
+        .await
+        .unwrap_throw();
+    let _stage = ctx.new_stage();
+}
+
+fn image_from_bytes(bytes: &[u8]) -> image::DynamicImage {
+    image::ImageReader::new(std::io::Cursor::new(bytes))
+        .with_guessed_format()
+        .expect_throw("could not guess format")
+        .decode()
+        .expect_throw("could not decode")
+}
+
+async fn load_test_img(path: &str) -> image::DynamicImage {
+    let result = loading_bytes::load(&format!("http://127.0.0.1:4000/test_img/{path}")).await;
+    let bytes = match result {
+        Ok(bytes) => bytes,
+        Err(e) => panic!("{e}"),
+    };
+    image_from_bytes(&bytes)
+}
+
+async fn assert_img_eq(filename: &str, seen: impl Into<image::DynamicImage>) {
+    let img: DynamicImage = seen.into();
+    let width = img.width();
+    let height = img.height();
+    let (pixel, bytes) = match img {
+        DynamicImage::ImageRgb8(image_buffer) => (PixelType::Rgb8, image_buffer.to_vec()),
+        DynamicImage::ImageRgba8(image_buffer) => (PixelType::Rgba8, image_buffer.to_vec()),
+        _ => panic!("Image type is not yet supported in the WASM tests"),
+    };
+    let wire_data = wire_types::Image {
+        width,
+        height,
+        bytes,
+        pixel,
+    };
+    let data = serde_json::to_string(&wire_data).unwrap();
+    let result = loading_bytes::post_json_wasm::<Result<(), wire_types::Error>>(
+        &format!("http://127.0.0.1:4000/assert_img_eq/{filename}"),
+        &data,
+    )
+    .await
+    .unwrap();
+
+    if let Err(Error { description }) = result {
+        panic!("{description}");
+    }
+}
+
+#[wasm_bindgen_test]
+async fn can_load_image() {
+    let _img = load_test_img("jolt.png").await;
+}
+
+#[wasm_bindgen_test]
+async fn can_img_diff() {
+    let a = load_test_img("jolt.png").await;
+    assert_img_eq("jolt.png", a).await;
+
+    let b = load_test_img("cmy_triangle/hdr.png").await;
+    assert_img_eq("cmy_triangle/hdr.png", b).await;
+}
+
+#[wasm_bindgen_test]
+async fn can_clear_background() {
+    let ctx = Context::try_new_headless(100, 100, None).await.unwrap();
+    let stage = ctx
+        .new_stage()
+        .with_background_color(Vec4::new(1.0, 0.0, 0.0, 1.0));
+    let frame = ctx.get_next_frame().unwrap();
+    stage.render(&frame.view());
+    let seen = frame.read_image().unwrap();
+    assert_img_eq("cmy_triangle/hdr.png", seen).await;
+}
+
+// #[wasm_bindgen_test]
+// #[should_panic]
+// async fn can_save_wrong_diffs() {
+//     let img = load_test_img("jolt.png").await;
+//     assert_img_eq("cmy_triangle/hdr.png", img).await;
+// }
+
+// #[wasm_bindgen_test]
+// async fn can_render_hello_triangle() {
+//     // This is a wasm version of cmy_triangle_sanity
+//     let ctx = Context::try_new_headless(100, 100, None).await.unwrap();
+//     let stage = ctx.new_stage().with_background_color(Vec4::splat(1.0));
+//     let _camera = stage.new_camera(Camera::default_ortho2d(100.0, 100.0));
+//     let _rez = stage
+//         .builder()
+//         .with_vertices(renderling::::right_tri_vertices())
+//         .build();
+
+//     let frame = ctx.get_next_frame().unwrap();
+//     stage.render(&frame.view());
+//     frame.present();
+
+//     let hdr_img = stage.hdr_texture().read_hdr_image(&ctx).unwrap();
+// }

--- a/crates/sandbox/src/main.rs
+++ b/crates/sandbox/src/main.rs
@@ -2,7 +2,8 @@
 //!
 //! This program will change on a whim and does not contain anything all that
 //! useful.
-use renderling::{math::UVec2, stage::Stage, Context};
+use glam::UVec2;
+use renderling::{stage::Stage, Context};
 use std::sync::Arc;
 use winit::{
     dpi::LogicalSize,
@@ -59,7 +60,7 @@ impl winit::application::ApplicationHandler for App {
             })
             .with_title("renderling gltf viewer");
         let window = Arc::new(event_loop.create_window(attributes).unwrap());
-        let ctx = Context::from_window(None, window.clone());
+        let ctx = futures_lite::future::block_on(Context::from_winit_window(None, window.clone()));
         let stage = ctx.new_stage();
         self.example = Some(Example { ctx, window, stage });
     }

--- a/crates/wire-types/Cargo.toml
+++ b/crates/wire-types/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "wire-types"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+serde.workspace = true

--- a/crates/wire-types/src/lib.rs
+++ b/crates/wire-types/src/lib.rs
@@ -1,0 +1,20 @@
+/// Supported pixel type.
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]
+pub enum PixelType {
+    Rgb8,
+    Rgba8,
+}
+
+/// Wire type for an RGB8 image.
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]
+pub struct Image {
+    pub width: u32,
+    pub height: u32,
+    pub bytes: Vec<u8>,
+    pub pixel: PixelType,
+}
+
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]
+pub struct Error {
+    pub description: String,
+}

--- a/crates/xtask/Cargo.toml
+++ b/crates/xtask/Cargo.toml
@@ -4,7 +4,14 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+axum.workspace = true
 clap.workspace = true
 env_logger.workspace = true
+image.workspace = true
+img-diff = { path = "../img-diff" }
 log.workspace = true
+new_mime_guess.workspace = true
 renderling_build = { path = "../renderling-build" }
+reqwest = { workspace = true, features = ["stream"] }
+tokio = { workspace = true, features = ["full"] }
+wire-types = { path = "../wire-types" }

--- a/crates/xtask/src/server.rs
+++ b/crates/xtask/src/server.rs
@@ -1,0 +1,115 @@
+//! Axum web server for running the webdriver proxy.
+//!
+//! This proxy server allows the WASM tests to request static assets,
+//! as well as report test failures in a (hopefully) nice way.
+
+use axum::{
+    body::{Body, Bytes},
+    extract::{Path, Request},
+    http::{HeaderMap, StatusCode},
+    response::{IntoResponse, Response},
+    routing::{any, get, options, post},
+    Json, Router,
+};
+use image::DynamicImage;
+use wire_types::Error;
+
+pub async fn serve() {
+    log::info!("starting the webdriver proxy");
+    let app = Router::new()
+        .route("/test_img/{*path}", get(static_file))
+        .route("/assert_img_eq/{*filename}", options(accept))
+        .route("/assert_img_eq/{*filename}", post(assert_img_eq))
+        .route("/{*rest}", any(accept));
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:4000")
+        .await
+        .unwrap();
+    axum::serve(listener, app).await.unwrap();
+}
+
+async fn static_file(Path(path): Path<String>) -> Result<Response, StatusCode> {
+    log::info!("requested static '{path}'");
+    let test_img = std::path::PathBuf::from(std::env!("CARGO_WORKSPACE_DIR")).join("test_img");
+    let path = test_img.join(path);
+    if path.exists() {
+        let bytes = tokio::fs::read(&path).await.map_err(|e| {
+            log::error!("could not read path '{path:?}': {e}");
+            StatusCode::BAD_REQUEST
+        })?;
+        let mime = new_mime_guess::from_path(path);
+        let mimetype = if let Some(mt) = mime.first() {
+            mt.to_string()
+        } else {
+            "application/octet-stream".to_owned()
+        };
+        let resp = Response::builder()
+            .status(StatusCode::OK)
+            .header("content-type", mimetype)
+            .header("access-control-allow-origin", "*")
+            .body(Body::from(Bytes::copy_from_slice(&bytes)))
+            .map_err(|e| {
+                log::error!("colud not create response: {e}");
+                StatusCode::INTERNAL_SERVER_ERROR
+            })?;
+        Ok(resp)
+    } else {
+        log::error!("{path:?} not found");
+        Err(StatusCode::NOT_FOUND)
+    }
+}
+
+async fn assert_img_eq_inner(
+    filename: &str,
+    img: wire_types::Image,
+) -> Result<(), wire_types::Error> {
+    let seen = match img.pixel {
+        wire_types::PixelType::Rgb8 => {
+            image::RgbImage::from_raw(img.width, img.height, img.bytes).map(DynamicImage::from)
+        }
+        wire_types::PixelType::Rgba8 => {
+            image::RgbaImage::from_raw(img.width, img.height, img.bytes).map(DynamicImage::from)
+        }
+    }
+    .ok_or_else(|| {
+        let description = "could not construct image".to_owned();
+        log::error!("{description}");
+        Error { description }
+    })?;
+
+    img_diff::assert_img_eq_cfg_result(filename, seen, Default::default()).map_err(|description| {
+        log::error!("{description}");
+        Error { description }
+    })
+}
+
+async fn assert_img_eq(
+    headers: HeaderMap,
+    Path(parts): Path<Vec<String>>,
+    Json(img): Json<wire_types::Image>,
+) -> Response {
+    let filename = parts.join("/");
+    log::info!("asserting '{filename}'");
+    log::info!("headers: {headers:#?}");
+
+    let result = assert_img_eq_inner(&filename, img).await;
+    Response::builder()
+        .status(StatusCode::OK)
+        .header("accept", "*/*")
+        .header("access-control-allow-origin", "*")
+        .header("access-control-allow-methods", "*")
+        .header("access-control-allow-headers", "*")
+        .body(Json(result).into_response().into_body())
+        .unwrap()
+}
+
+async fn accept(request: Request) -> Response {
+    log::info!("accept: {request:#?}");
+    Response::builder()
+        .status(StatusCode::OK)
+        .header("accept", "*/*")
+        .header("access-control-allow-origin", "*")
+        .header("access-control-allow-methods", "*")
+        .header("access-control-allow-headers", "*")
+        .body(Body::default())
+        .unwrap()
+}


### PR DESCRIPTION
This adds proper test infrastructure for WASM tests (through `wasm-bindgen-test`).

* adds an `axum` server to supply tests with static files from `test_img`, as well as the ability to diff images and save to the filesystem.
* removes `futures_lite`, except from tests, as calling `futures_lite::future::block_on` on web panics
* changes `Context` API to be async
* reading images from GPU is now async 

Fixes #196.